### PR TITLE
fix GPA display

### DIFF
--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/common/transcript.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/common/transcript.js
@@ -365,7 +365,7 @@ export const renderTranscript = certificate => {
 // display GPA for PET and DPLUS
 export const renderPETGPA = GPA => (
   <span>
-    Grade Point Average (GPA): {GPA} /4.00
+    Grade Point Average (GPA): {GPA.toFixed(2)} /4.00
     <br />
   </span>
 );


### PR DESCRIPTION
---
name: Certificate Template Addition
about: This is the workflow for requesting new certificate templates to be added to
  the OpenCerts repository
title: "[New Template]"
labels: new template
assignees: ''

---

# Pull Request Guidelines for Adding Certificate Templates
This document is a work in progress but here are some basic checks. As these are only basic guidelines, meeting the below doesn't indicate there will be no issues with your pull request.

### Pre-merge checks

- [X ] Did not modify any files outside of your organisation's template folder (e.g package-lock.json or anything else)
- [X] Ensure that your code has been [rebased](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) on top of latest OpenCerts master
- [X ] Linter issues resolved (Run `npm run lint:fix` to see issues)
- [X] `npm run test` passes
- [X] `npm run test:integration` passes
- [] [Travis Build passes](https://docs.travis-ci.com/user/for-beginners/)

### Certificate Template 
- [X] No more than 5 templates or 25 added/modified files in the pull request
- [X] Ensure that your .opencert file's data complies with the intentions of the OpenCerts' schema - e.g recipient related information is inside the `recipient` object, etc.
- [X] Integration test for each template that checks that the correct rendering is done given a sample certificate
- [X] Sample certificate file included for each template, located alongside the integration test for each template
- [X] Sample certificates must obviously be a sample certificate
  - [ ] Obviously fictitious name
  - [ ] Obviously sample signatory images
- [X] No fixed-size raster images as part of certificate layout
- [X] Mobile responsive design
- [X] Date parsing should be localised to template author's timezone
- [X] Webpack chunking code is correct
  - [ ] Has chunking code
  - [ ] Same chunking code as the other certificates belonging to that institute
- [X] Certificate Store Addresses have been updated
  - [ ] Template Whitelist
  - [ ] Registry
- [X] Template should not be using resources(images etc.) on the website outside of their own folder (e.g institute logo shouldn't be used from /static because there's no guarantee it will not change)
