### PR TITLE
chore(template): Changing renderer from frameless-viewer to legacy.opencerts.io

### DIFF
--- a/src/components/CertificateViewer.js
+++ b/src/components/CertificateViewer.js
@@ -9,6 +9,7 @@ import ErrorBoundary from "./ErrorBoundary";
 import DecentralisedRenderer from "./DecentralisedTemplateRenderer/DecentralisedRenderer";
 import MultiTabs from "./MultiTabs";
 import { selectTemplateTab as selectTemplateTabAction } from "../reducers/certificate";
+import { LEGACY_OPENCERTS_RENDERER } from "../config";
 
 const CertificateSharingForm = dynamic(
   import("./CertificateSharing/CertificateSharingForm")
@@ -94,7 +95,7 @@ const CertificateViewer = props => {
         certificate={document}
         source={`${
           typeof document.data.$template === "string"
-            ? "/frameless-viewer"
+            ? LEGACY_OPENCERTS_RENDERER
             : certificate.$template.url
         }`}
       />

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -28,6 +28,8 @@ export const EMAIL_API_URL = IS_MAINNET
   ? "https://api.opencerts.io/email"
   : "https://api-ropsten.opencerts.io/email";
 export const INFURA_PROJECT_ID = "1f1ff2b3fca04f8d99f67d465c59e4ef";
+export const LEGACY_OPENCERTS_RENDERER =
+  "https://legacy.opencerts.io/frameless-viewer";
 
 export const DEFAULT_SEO = {
   title: "An easy way to check and verify your certificates",


### PR DESCRIPTION
Using renderer from https://legacy.opencerts.io/frameless-viewer