### PR TITLE
Fix(Reducers): Disable setting activeTemplateTab when registering templates

### DIFF
--- a/src/reducers/certificate.js
+++ b/src/reducers/certificate.js
@@ -325,8 +325,7 @@ export default function reducer(state = initialState, action) {
     case types.CERTIFICATE_TEMPLATE_REGISTER:
       return {
         ...state,
-        templates: action.payload,
-        activeTemplateTab: 0
+        templates: action.payload
       };
     case types.CERTIFICATE_TEMPLATE_SELECT_TAB:
       return {

--- a/src/reducers/certificate.test.js
+++ b/src/reducers/certificate.test.js
@@ -56,8 +56,7 @@ describe("reducers", () => {
             id: "transcript",
             label: "Transcript"
           }
-        ],
-        activeTemplateTab: 0
+        ]
       };
       expect(reducer(prevState, action)).toEqual(expectedState);
     });
@@ -85,7 +84,7 @@ describe("reducers", () => {
           },
           { id: "certificate", label: "Certificate" }
         ],
-        activeTemplateTab: 1
+        activeTemplateTab: 0
       };
       const expectedState = {
         foo: "bar",


### PR DESCRIPTION
In reducers/certificate, remove the activeTemplateTab: 0 from CERTIFICATE_TEMPLATE_REGISTER. This is so that when we updateTemplateTabs, activeTab will not keep switching back to 0. 