### PR TITLE
RP regsitry name contains two ":"

### DIFF
--- a/static/registry.json
+++ b/static/registry.json
@@ -130,7 +130,7 @@
       "displayCard": false
     },
     "0x061aFcFF60b90E0F633F8ef157e01BaB9b2FfDD3": {
-      "name:": "ROPSTEN: Republic Polytechnic",
+      "name": "ROPSTEN: Republic Polytechnic",
       "displayCard": false
     }
   }


### PR DESCRIPTION
- extra ":" was causing the problem to get the name of the registry.

