### PR TITLE
bug/printWatermarkNotShowing

### DIFF
--- a/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
+++ b/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
@@ -13,6 +13,7 @@ import {
 } from "../../reducers/certificate";
 import { analyticsEvent } from "../Analytics";
 import { getAnalyticsStores } from "../../sagas/certificate";
+import styles from "../certificateViewer.scss";
 
 class DecentralisedRenderer extends Component {
   constructor(props) {
@@ -94,11 +95,11 @@ class DecentralisedRenderer extends Component {
       <iframe
         title="Decentralised Rendered Certificate"
         id="iframe"
+        className={styles["decentralised-renderer"]}
         ref={iframe => {
           this.iframe = iframe;
         }}
         src={this.props.source}
-        style={{ width: "100%", border: 0, position: "relative" }}
       />
     );
   }

--- a/src/components/certificateViewer.scss
+++ b/src/components/certificateViewer.scss
@@ -2,9 +2,20 @@
 
 @media print {
   #header-ui,
+  #renderer-loader,
   #top-header-ui {
     display: none;
   }
+
+  .decentralised-renderer {
+    position: static !important;
+  }
+}
+
+.decentralised-renderer {
+  width: 100%;
+  border: 0;
+  position: relative;
 }
 
 :global(.frameless-tabs .react-tabs .d-lg-none.d-xl-none) {


### PR DESCRIPTION
This issue arose because the iframe style was set to 'relative' with respect to the renderer-loader with position 'absolute'.

To fix this, we set the position to be static when @media print in .certificateViewer.scss. 