### PR TITLE
feat(config): introduced configurable url for legacy renderer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,8 @@ module.exports = withBundleAnalyzer(
     },
     // Variables passed to both server and client
     publicRuntimeConfig: {
-      network: process.env.NET
+      network: process.env.NET,
+      legacyRendererUrl: process.env.LEGACY_URL
     }
   })
 );

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext .js --max-warnings 0",
     "lint:fix": "eslint . --ext .js --fix",
     "build": "next build",
+    "start:local": "LEGACY_RENDERER_URL=\"http://localhost:3000\" next start -p 3001",
     "build:static": "next build && npm run export",
     "export": "next export",
     "start": "next build && next start",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -28,7 +28,8 @@ export const EMAIL_API_URL = IS_MAINNET
   ? "https://api.opencerts.io/email"
   : "https://api-ropsten.opencerts.io/email";
 export const INFURA_PROJECT_ID = "1f1ff2b3fca04f8d99f67d465c59e4ef";
-export const LEGACY_OPENCERTS_RENDERER = "https://legacy.opencerts.io/";
+export const LEGACY_OPENCERTS_RENDERER =
+  publicRuntimeConfig.legacyRendererUrl || "https://legacy.opencerts.io/";
 
 export const DEFAULT_SEO = {
   title: "An easy way to check and verify your certificates",


### PR DESCRIPTION
can now use `npm run start:local` to point legacy renderer to localhost 
alternatively to point to another url use the LEGACY_RENDERER_URL env var