### PR TITLE
fix(dropbox): Dropbox not showing error for certificate with malformed type  

### DIFF
--- a/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
+++ b/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
@@ -12,8 +12,11 @@ import {
   selectTemplateTab as selectTemplateTabAction
 } from "../../reducers/certificate";
 import { analyticsEvent } from "../Analytics";
-import { getAnalyticsStores } from "../../sagas/certificate";
 import styles from "../certificateViewer.scss";
+
+function getDocumentStore(issuer) {
+  return issuer.certificateStore || issuer.documentStore;
+}
 
 class DecentralisedRenderer extends Component {
   constructor(props) {
@@ -85,7 +88,9 @@ class DecentralisedRenderer extends Component {
 
     analyticsEvent(window, {
       category: "CERTIFICATE_VIEWED",
-      action: getAnalyticsStores(getData(this.props.certificate)),
+      action: get(getData(this.props.certificate), "issuers", [])
+        .map(issuer => getDocumentStore(issuer))
+        .toString(),
       label: get(getData(this.props.certificate), "id")
     });
   }

--- a/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
+++ b/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
@@ -13,10 +13,7 @@ import {
 } from "../../reducers/certificate";
 import { analyticsEvent } from "../Analytics";
 import styles from "../certificateViewer.scss";
-
-function getDocumentStore(issuer) {
-  return issuer.certificateStore || issuer.documentStore;
-}
+import { getDocumentIssuerStores } from "../../utils/certificate";
 
 class DecentralisedRenderer extends Component {
   constructor(props) {
@@ -86,12 +83,11 @@ class DecentralisedRenderer extends Component {
       frame.renderDocument(getData(this.props.certificate))
     );
 
+    const certificateData = getData(this.props.certificate);
     analyticsEvent(window, {
       category: "CERTIFICATE_VIEWED",
-      action: get(getData(this.props.certificate), "issuers", [])
-        .map(issuer => getDocumentStore(issuer))
-        .toString(),
-      label: get(getData(this.props.certificate), "id")
+      action: getDocumentIssuerStores(certificateData),
+      label: get(certificateData, "id")
     });
   }
 

--- a/src/reducers/certificate.js
+++ b/src/reducers/certificate.js
@@ -370,11 +370,10 @@ export function verifyingCertificateIssuerSuccess({ issuerIdentities }) {
   };
 }
 
-export function verifyingCertificateIssuerFailure({ error, certificate }) {
+export function verifyingCertificateIssuerFailure({ error }) {
   return {
     type: types.VERIFYING_CERTIFICATE_ISSUER_FAILURE,
-    error,
-    certificate
+    error
   };
 }
 
@@ -384,11 +383,10 @@ export function verifyingCertificateStoreSuccess() {
   };
 }
 
-export function verifyingCertificateStoreFailure({ error, certificate }) {
+export function verifyingCertificateStoreFailure({ error }) {
   return {
     type: types.VERIFYING_CERTIFICATE_STORE_FAILURE,
-    error,
-    certificate
+    error
   };
 }
 
@@ -398,11 +396,10 @@ export function verifyingCertificateRevocationSuccess() {
   };
 }
 
-export function verifyingCertificateRevocationFailure({ error, certificate }) {
+export function verifyingCertificateRevocationFailure({ error }) {
   return {
     type: types.VERIFYING_CERTIFICATE_REVOCATION_FAILURE,
-    error,
-    certificate
+    error
   };
 }
 
@@ -412,11 +409,10 @@ export function verifyingCertificateIssuedSuccess() {
   };
 }
 
-export function verifyingCertificateIssuedFailure({ error, certificate }) {
+export function verifyingCertificateIssuedFailure({ error }) {
   return {
     type: types.VERIFYING_CERTIFICATE_ISSUED_FAILURE,
-    error,
-    certificate
+    error
   };
 }
 
@@ -426,11 +422,10 @@ export function verifyingCertificateHashSuccess() {
   };
 }
 
-export function verifyingCertificateHashFailure({ error, certificate }) {
+export function verifyingCertificateHashFailure({ error }) {
   return {
     type: types.VERIFYING_CERTIFICATE_HASH_FAILURE,
-    error,
-    certificate
+    error
   };
 }
 

--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -449,92 +449,78 @@ export function* networkReset() {
   });
 }
 
-export function* getAnalyticsStores() {
+export function* getAnalyticsDetails() {
   try {
     const rawCertificate = yield select(getCertificate);
     const certificate = getData(rawCertificate);
 
-    return get(certificate, "issuers", [])
+    const storeAddresses = get(certificate, "issuers", [])
       .map(issuer => getDocumentStore(issuer))
       .toString();
+    const id = get(certificate, "id");
+    return { storeAddresses, id };
   } catch (e) {
-    return null;
-  }
-}
-
-export function* getCertificateId() {
-  try {
-    const rawCertificate = yield select(getCertificate);
-    const certificate = getData(rawCertificate);
-
-    return get(certificate, "id");
-  } catch (e) {
-    return null;
+    return {};
   }
 }
 
 export function* analyticsIssuerFail() {
-  const storeAddresses = yield call(getAnalyticsStores);
-  const certificateId = yield call(getCertificateId);
+  const { storeAddresses, id } = yield call(getAnalyticsDetails);
 
-  if (storeAddresses && certificateId)
+  if (storeAddresses && id)
     yield analyticsEvent(window, {
       category: "CERTIFICATE_ERROR",
       action: storeAddresses,
-      label: certificateId,
+      label: id,
       value: ANALYTICS_VERIFICATION_ERROR_CODE.ISSUER_IDENTITY
     });
 }
 
 export function* analyticsHashFail() {
-  const storeAddresses = yield call(getAnalyticsStores);
-  const certificateId = yield call(getCertificateId);
+  const { storeAddresses, id } = yield call(getAnalyticsDetails);
 
-  if (storeAddresses && certificateId) {
+  if (storeAddresses && id) {
     yield analyticsEvent(window, {
       category: "CERTIFICATE_ERROR",
       action: storeAddresses,
-      label: certificateId,
+      label: id,
       value: ANALYTICS_VERIFICATION_ERROR_CODE.CERTIFICATE_HASH
     });
   }
 }
 
 export function* analyticsIssuedFail() {
-  const storeAddresses = yield call(getAnalyticsStores);
-  const certificateId = yield call(getCertificateId);
+  const { storeAddresses, id } = yield call(getAnalyticsDetails);
 
-  if (storeAddresses && certificateId)
+  if (storeAddresses && id)
     yield analyticsEvent(window, {
       category: "CERTIFICATE_ERROR",
       action: storeAddresses,
-      label: certificateId,
+      label: id,
       value: ANALYTICS_VERIFICATION_ERROR_CODE.UNISSUED_CERTIFICATE
     });
 }
 
 export function* analyticsRevocationFail() {
-  const storeAddresses = yield call(getAnalyticsStores);
-  const certificateId = yield call(getCertificateId);
+  const { storeAddresses, id } = yield call(getAnalyticsDetails);
 
-  if (storeAddresses && certificateId)
+  if (storeAddresses && id)
     yield analyticsEvent(window, {
       category: "CERTIFICATE_ERROR",
       action: storeAddresses,
-      label: certificateId,
+      label: id,
       value: ANALYTICS_VERIFICATION_ERROR_CODE.REVOKED_CERTIFICATE
     });
 }
 
 export function* analyticsStoreFail() {
-  const storeAddresses = yield call(getAnalyticsStores);
-  const certificateId = yield call(getCertificateId);
+  const { storeAddresses, id } = yield call(getAnalyticsDetails);
 
-  if (storeAddresses && certificateId)
+  if (storeAddresses && id)
     yield analyticsEvent(window, {
       category: "CERTIFICATE_ERROR",
       action: storeAddresses,
-      label: certificateId,
+      label: id,
       value: ANALYTICS_VERIFICATION_ERROR_CODE.CERTIFICATE_STORE
     });
 }

--- a/src/sagas/certificate.test.js
+++ b/src/sagas/certificate.test.js
@@ -19,7 +19,8 @@ import {
   verifyCertificateStore,
   verifyCertificateRegistryIssuer,
   verifyCertificateDnsIssuer,
-  getDetailedIssuerStatus
+  getDetailedIssuerStatus,
+  getAnalyticsDetails
 } from "./certificate";
 import {
   getCertificate,
@@ -343,7 +344,6 @@ describe("sagas/certificate", () => {
       describe("should put a verifying certificate store failure when:", () => {
         test("the certificate issuer's document store has an invalid ethereum address and is not an ens address", () => {
           const { invalidCert } = whenThereIsOneInvalidCertStoreAddress();
-          const certData = getData(invalidCert);
           const errorMsg = "Invalid ENS";
 
           const verificationSaga = verifyCertificateStore({
@@ -354,8 +354,7 @@ describe("sagas/certificate", () => {
           expect(verificationSaga.throw(new Error(errorMsg)).value).toEqual(
             put(
               verifyingCertificateStoreFailure({
-                error: errorMsg,
-                certificate: certData
+                error: errorMsg
               })
             )
           );
@@ -365,7 +364,6 @@ describe("sagas/certificate", () => {
 
         test("the certificate issuer's document store address has the wrong smart contract", () => {
           const { invalidCert } = whenThereIsWrongSmartContract();
-          const certData = getData(invalidCert);
           const errorMsg = "Invalid Smart Contract";
 
           const verificationSaga = verifyCertificateStore({
@@ -377,8 +375,7 @@ describe("sagas/certificate", () => {
           expect(verificationSaga.throw(new Error(errorMsg)).value).toEqual(
             put(
               verifyingCertificateStoreFailure({
-                error: errorMsg,
-                certificate: certData
+                error: errorMsg
               })
             )
           );
@@ -421,7 +418,6 @@ describe("sagas/certificate", () => {
           invalidCert,
           ensName
         } = whenThereIsOneInvalidEnsNameAndOneValidEthereumAddress();
-        const certData = getData(invalidCert);
         const errorMsg = "Invalid ENS";
 
         const verificationSaga = verifyCertificateStore({
@@ -434,8 +430,7 @@ describe("sagas/certificate", () => {
         expect(verificationSaga.throw(new Error(errorMsg)).value).toEqual(
           put(
             verifyingCertificateStoreFailure({
-              error: errorMsg,
-              certificate: certData
+              error: errorMsg
             })
           )
         );
@@ -447,7 +442,6 @@ describe("sagas/certificate", () => {
           ensName,
           ethereumAddress
         } = whenThereIsOneInvalidEthereumAddressAndOneValidENS();
-        const certData = getData(invalidCert);
         const errorMsg = "Invalid ENS";
 
         const verificationSaga = verifyCertificateStore({
@@ -461,8 +455,7 @@ describe("sagas/certificate", () => {
         expect(verificationSaga.throw(new Error(errorMsg)).value).toEqual(
           put(
             verifyingCertificateStoreFailure({
-              error: errorMsg,
-              certificate: certData
+              error: errorMsg
             })
           )
         );
@@ -475,7 +468,6 @@ describe("sagas/certificate", () => {
           ensName,
           ethereumAddress
         } = whenThereAreInvalidEnsNameAndEthereumAddress();
-        const certData = getData(invalidCert);
         const errorMsg = "Invalid ENS";
 
         const verificationSaga = verifyCertificateStore({
@@ -489,8 +481,7 @@ describe("sagas/certificate", () => {
         expect(verificationSaga.throw(new Error(errorMsg)).value).toEqual(
           put(
             verifyingCertificateStoreFailure({
-              error: errorMsg,
-              certificate: certData
+              error: errorMsg
             })
           )
         );
@@ -596,7 +587,6 @@ describe("sagas/certificate", () => {
       expect(resolvedPut).toEqual(
         put(
           verifyingCertificateIssuerFailure({
-            certificate: certData,
             error: errorMsg
           })
         )
@@ -719,8 +709,7 @@ describe("sagas/certificate", () => {
       expect(resolvedPut).toEqual(
         put(
           verifyingCertificateIssuerFailure({
-            error: "Issuer identity cannot be verified: 0xabc",
-            certificate: certData
+            error: "Issuer identity cannot be verified: 0xabc"
           })
         )
       );
@@ -740,11 +729,16 @@ describe("sagas/certificate", () => {
     });
 
     test("analyticsIssuerFail should report to GA with errorType = 0", () => {
-      const {
-        testCert,
-        ethereumAddresses
-      } = whenThereIsOneEthereumAddressIssuer();
-      analyticsIssuerFail({ certificate: getData(testCert) }).next();
+      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
+      const saga = analyticsIssuerFail();
+
+      const callGetAnalyticsDetails = saga.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
+
+      saga.next({
+        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
+        id: "certificate-id"
+      });
 
       expect(global.window.ga.args[0]).toEqual([
         "send",
@@ -757,11 +751,16 @@ describe("sagas/certificate", () => {
     });
 
     test("analyticsHashFail should report to GA with errorType = 1", () => {
-      const {
-        testCert,
-        ethereumAddresses
-      } = whenThereIsOneEthereumAddressIssuer();
-      analyticsHashFail({ certificate: getData(testCert) }).next();
+      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
+      const saga = analyticsHashFail();
+
+      const callGetAnalyticsDetails = saga.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
+
+      saga.next({
+        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
+        id: "certificate-id"
+      });
 
       expect(global.window.ga.args[0]).toEqual([
         "send",
@@ -774,11 +773,16 @@ describe("sagas/certificate", () => {
     });
 
     test("analyticsIssuedFail should report to GA with errorType = 2", () => {
-      const {
-        testCert,
-        ethereumAddresses
-      } = whenThereIsOneEthereumAddressIssuer();
-      analyticsIssuedFail({ certificate: getData(testCert) }).next();
+      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
+      const saga = analyticsIssuedFail();
+
+      const callGetAnalyticsDetails = saga.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
+
+      saga.next({
+        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
+        id: "certificate-id"
+      });
 
       expect(global.window.ga.args[0]).toEqual([
         "send",
@@ -791,13 +795,16 @@ describe("sagas/certificate", () => {
     });
 
     test("analyticsRevocationFail should report to GA with errorType = 3", () => {
-      const {
-        testCert,
-        ethereumAddresses
-      } = whenThereIsOneEthereumAddressIssuer();
-      analyticsRevocationFail({
-        certificate: getData(testCert)
-      }).next();
+      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
+      const saga = analyticsRevocationFail();
+
+      const callGetAnalyticsDetails = saga.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
+
+      saga.next({
+        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
+        id: "certificate-id"
+      });
 
       expect(global.window.ga.args[0]).toEqual([
         "send",
@@ -894,7 +901,6 @@ describe("sagas/certificate", () => {
       expect(doneWithVerification.value).toEqual(
         put(
           verifyingCertificateRevocationFailure({
-            certificate: getData(certificate),
             error:
               "Certificate has been revoked, revoked hash: 0xfcfce0e79adc002c1fd78a2a02c768c0fdc00e5b96f1da8ef80bed02876e18d1"
           })
@@ -930,7 +936,6 @@ describe("sagas/certificate", () => {
       expect(generator.next().value).toEqual(
         put(
           verifyingCertificateHashFailure({
-            certificate: getData(testCert),
             error: "Certificate data does not match target hash"
           })
         )
@@ -972,7 +977,6 @@ describe("sagas/certificate", () => {
       expect(generator.next([true, false]).value).toEqual(
         put(
           verifyingCertificateIssuedFailure({
-            certificate: getData(certificate),
             error: "Certificate has not been issued"
           })
         )

--- a/src/sagas/certificate.test.js
+++ b/src/sagas/certificate.test.js
@@ -20,7 +20,8 @@ import {
   verifyCertificateRegistryIssuer,
   verifyCertificateDnsIssuer,
   getDetailedIssuerStatus,
-  getAnalyticsDetails
+  getAnalyticsDetails,
+  triggerAnalytics
 } from "./certificate";
 import {
   getCertificate,
@@ -728,15 +729,13 @@ describe("sagas/certificate", () => {
       global.window.ga = undefined;
     });
 
-    test("analyticsIssuerFail should report to GA with errorType = 0", () => {
-      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
-      const saga = analyticsIssuerFail();
+    test("triggerAnalytics should get details and fire the analytics event with correct error code", () => {
+      const analyticsGenerator = triggerAnalytics(1337);
 
-      const callGetAnalyticsDetails = saga.next();
+      const callGetAnalyticsDetails = analyticsGenerator.next();
       expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
-
-      saga.next({
-        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
+      analyticsGenerator.next({
+        storeAddresses: "storeAdd1,storeAdd2",
         id: "certificate-id"
       });
 
@@ -744,76 +743,38 @@ describe("sagas/certificate", () => {
         "send",
         "event",
         "CERTIFICATE_ERROR",
-        ethereumAddresses[0],
+        "storeAdd1,storeAdd2",
         "certificate-id",
-        0
+        1337
       ]);
+    });
+
+    test("analyticsIssuerFail should report to GA with errorType = 0", () => {
+      const analyticsGenerator = analyticsIssuerFail();
+
+      const callGetAnalyticsDetails = analyticsGenerator.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(triggerAnalytics, 0));
     });
 
     test("analyticsHashFail should report to GA with errorType = 1", () => {
-      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
-      const saga = analyticsHashFail();
+      const analyticsGenerator = analyticsHashFail();
 
-      const callGetAnalyticsDetails = saga.next();
-      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
-
-      saga.next({
-        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
-        id: "certificate-id"
-      });
-
-      expect(global.window.ga.args[0]).toEqual([
-        "send",
-        "event",
-        "CERTIFICATE_ERROR",
-        ethereumAddresses[0],
-        "certificate-id",
-        1
-      ]);
+      const callGetAnalyticsDetails = analyticsGenerator.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(triggerAnalytics, 1));
     });
 
     test("analyticsIssuedFail should report to GA with errorType = 2", () => {
-      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
-      const saga = analyticsIssuedFail();
+      const analyticsGenerator = analyticsIssuedFail();
 
-      const callGetAnalyticsDetails = saga.next();
-      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
-
-      saga.next({
-        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
-        id: "certificate-id"
-      });
-
-      expect(global.window.ga.args[0]).toEqual([
-        "send",
-        "event",
-        "CERTIFICATE_ERROR",
-        ethereumAddresses[0],
-        "certificate-id",
-        2
-      ]);
+      const callGetAnalyticsDetails = analyticsGenerator.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(triggerAnalytics, 2));
     });
 
     test("analyticsRevocationFail should report to GA with errorType = 3", () => {
-      const { ethereumAddresses } = whenThereIsOneEthereumAddressIssuer();
-      const saga = analyticsRevocationFail();
+      const analyticsGenerator = analyticsRevocationFail();
 
-      const callGetAnalyticsDetails = saga.next();
-      expect(callGetAnalyticsDetails.value).toEqual(call(getAnalyticsDetails));
-
-      saga.next({
-        storeAddresses: "0xd2536C3cc7eb51447F6dA8d60Ba6344A79590b4F",
-        id: "certificate-id"
-      });
-
-      expect(global.window.ga.args[0]).toEqual([
-        "send",
-        "event",
-        "CERTIFICATE_ERROR",
-        ethereumAddresses[0],
-        "certificate-id",
-        3
-      ]);
+      const callGetAnalyticsDetails = analyticsGenerator.next();
+      expect(callGetAnalyticsDetails.value).toEqual(call(triggerAnalytics, 3));
     });
   });
 

--- a/src/utils/certificate.js
+++ b/src/utils/certificate.js
@@ -1,0 +1,9 @@
+import { get } from "lodash";
+
+export const getDocumentStore = issuer =>
+  issuer.certificateStore || issuer.documentStore;
+
+export const getDocumentIssuerStores = document => {
+  const issuers = get(document, "issuers", []);
+  return issuers.map(getDocumentStore).join(",");
+};

--- a/src/utils/certificate.test.js
+++ b/src/utils/certificate.test.js
@@ -1,0 +1,14 @@
+import { getDocumentStore, getDocumentIssuerStores } from "./certificate";
+
+test("getDocumentStore should return the store address if it's using certificateStore or documentStore", () => {
+  expect(getDocumentStore({ certificateStore: "store" })).toBe("store");
+  expect(getDocumentStore({ documentStore: "store" })).toBe("store");
+});
+
+test("getDocumentIssuerStores should return a string of all issuers' stores", () => {
+  expect(
+    getDocumentIssuerStores({
+      issuers: [{ certificateStore: "0xStoreA" }, { documentStore: "0xStoreB" }]
+    })
+  ).toBe("0xStoreA,0xStoreB");
+});


### PR DESCRIPTION
This fixes #414.

The problem was that in previous error handling method, we are sending an action with `certificate: getData(rawCertificate)`. The problem is when `getData` fail, the error handling function throws instead and the action for the error is not dispatched. 

The fix is to remove all the certificate in the error handling function since there is no use of it being sent in the action anyway. Also in the same PR, refactored the analytics handling saga and extracted common certificate methods to it's own utils. 