### PR TITLE
wip: feat: display print help message on how to print certificate

### DIFF
--- a/pages/viewer.js
+++ b/pages/viewer.js
@@ -5,13 +5,11 @@ import { connect } from "react-redux";
 import NavigationBar from "../src/components/Layout/NavigationBar";
 import FooterBar from "../src/components/Layout/FooterBar";
 import ViewerPageContainer from "../src/components/ViewerPageContainer";
-import PrintWatermark from "../src/components/PrintWatermark";
 import { DEFAULT_SEO } from "../src/config";
 
 const VerifierPage = props => (
   <>
     <NextSeo config={DEFAULT_SEO} />
-    <PrintWatermark />
     <NavigationBar />
     <ViewerPageContainer document={props.document} />
     <FooterBar />

--- a/src/components/CertificateViewer.js
+++ b/src/components/CertificateViewer.js
@@ -115,7 +115,9 @@ export const CertificateViewer = props => {
       {isInRegistry ? (
         <div
           id="status-banner-container"
-          className={`${styles["status-banner-container"]} ${styles.valid}`}
+          className={`${styles["status-banner-container"]} ${
+            styles.valid
+          } exact-print`}
         >
           <div className={`${styles["status-banner"]}`}>
             Certificate issuer is in the SkillsFuture Singapore registry for

--- a/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
+++ b/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.js
@@ -80,6 +80,10 @@ export const DecentralisedRenderer = ({
         onSelectTemplate={index => toFrame.current.selectTemplateTab(index)}
       />
       <div>
+        <h2 className="print-only exact-print text-center center m-4 mb-3 mt-5 alert alert-warning">
+          If you want to print the certificate, please click on the highlighted
+          button above.
+        </h2>
         <div id={styles["renderer-loader"]} className="text-blue">
           <i className="fas fa-spinner fa-pulse fa-3x" />
           <div className="m-3" style={{ fontSize: "1.5rem" }}>

--- a/src/components/DecentralisedTemplateRenderer/decentralisedRenderer.scss
+++ b/src/components/DecentralisedTemplateRenderer/decentralisedRenderer.scss
@@ -2,10 +2,6 @@
   #renderer-loader {
     display: none;
   }
-
-  .decentralised-renderer {
-    position: static !important;
-  }
 }
 
 .decentralised-renderer {

--- a/src/components/Layout/NavigationBar/navBar.scss
+++ b/src/components/Layout/NavigationBar/navBar.scss
@@ -12,15 +12,11 @@
 }
 
 .navbar {
-  display: block;
-  justify-content: flex-start;
-  margin: 0 auto;
-  background-color: $brand-dark;
-  padding: 1rem 2rem;
-
-  @media print {
-    display: none;
-  }
+    display: block;
+    justify-content: flex-start;
+    margin: 0 auto;
+    background-color: $brand-dark;
+    padding: 1rem 2rem;
 }
 
 .nav-item {

--- a/src/components/Layout/footer.scss
+++ b/src/components/Layout/footer.scss
@@ -26,9 +26,3 @@
     margin-left: 2rem;
   }
 }
-
-@media print {
-  #footer-print {
-    display: none;
-  }
-}

--- a/src/components/PrintWatermark.js
+++ b/src/components/PrintWatermark.js
@@ -8,7 +8,6 @@ const PrintWatermark = () => (
       backgroundImage: 'url("/static/images/watermark.svg")',
       backgroundRepeat: "repeat"
     }}
-    className="print-only"
   />
 );
 

--- a/src/components/certificateViewer.scss
+++ b/src/components/certificateViewer.scss
@@ -1,15 +1,15 @@
 @import "../styles/main.scss";
 
 @media print {
-  #header-ui,
-  #renderer-loader,
-  .status-banner-container,
-  #top-header-ui {
+  #header-ui {
     display: none !important;
   }
 
   iframe {
-    height: 99vh; /* dont use 100vh otherwise a second blank page appear when printing */
+    height: 0 !important;
+    width: 0 !important;
+    min-height: 0 !important;
+    margin: 0 !important;
   }
 }
 
@@ -151,6 +151,12 @@
     width: 100%;
   }
 }
+.print-btn {
+  @media print {
+    box-shadow: 0px 0px 10px 2px $brand-blue !important;
+    background-color: lighten($brand-blue, 10%);
+  }
+}
 
 .print-btn:hover,
 .send-btn:hover {
@@ -186,7 +192,7 @@
   }
 }
 
-@media only screen and (min-width: 850px) {
+@media (min-width: 850px), print {
   .container > :global(.row) {
     justify-content: space-between;
   }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -9,6 +9,7 @@ $grey-blue: #c1c9d1;
 $brand-dark: #324353;
 $faint-blue: #f5f8fb;
 $faint-green: #f5fbf7;
+$color-white: #ffffff;
 
 $header-ui-bg: #f3f8fc;
 $low-translucency-white: rgba(255, 255, 255, 0.7);

--- a/static/style.css
+++ b/static/style.css
@@ -60,16 +60,9 @@ h6 {
   display: none;
 }
 
-.screen-only {
-  display: block;
-}
-
 @media print {
   .print-only {
     display: block;
-  }
-  .screen-only {
-    display: none;
   }
 }
 


### PR DESCRIPTION
For the moment if someone print using normal way (browser) then we will face the initial issue (print behaviour is 🥺). Some cases:
- user use a shortcut (https://github.com/OpenCerts/opencerts-website/issues/446) -> it's doable even though not that trivial (also need to take care of Mac user)
- user use browser menu (can't catch)
- user use contextual menu (I'm not sure can catch but I'm sure can't catch on all browser)
- more?

So this is a generic way to solve all those issues. Can enhance with catching the shortcut later