### PR TITLE
fix: #466 - trigger template update when clicking on mobile tab

### DIFF
--- a/src/components/MultiTabs.js
+++ b/src/components/MultiTabs.js
@@ -51,6 +51,7 @@ const MultiTabs = ({ resetData, templates, onSelectTemplate }) => {
           activeIdx={selectedTemplate}
           toggle={idx => {
             setSelectedTemplate(idx);
+            onSelectTemplate(idx);
           }}
         />
       </div>


### PR DESCRIPTION
resolved #466 