### PR TITLE
feat: add some analytics :)

### DIFF
--- a/src/components/Analytics/analytics.test.ts
+++ b/src/components/Analytics/analytics.test.ts
@@ -1,4 +1,5 @@
-import { analyticsEvent, stringifyEvent, validateEvent } from "./index";
+import { v2 } from "@govtechsg/open-attestation";
+import { analyticsEvent, sendEventCertificateViewedDetailed, stringifyEvent, validateEvent } from "./index";
 
 const evt = {
   category: "TEST_CATEGORY",
@@ -74,7 +75,7 @@ describe("event", () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
     // @ts-ignore
     analyticsEvent(win, evt);
-    expect(win.ga).toHaveBeenCalledWith("send", "event", "TEST_CATEGORY", "TEST_ACTION", "TEST_LABEL", 2);
+    expect(win.ga).toHaveBeenCalledWith("send", "event", "TEST_CATEGORY", "TEST_ACTION", "TEST_LABEL", 2, undefined);
   });
 
   it("throws if there is a validation error", () => {
@@ -83,5 +84,141 @@ describe("event", () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
     // @ts-ignore
     expect(() => analyticsEvent(win, errEvt)).toThrow("Value must be a number");
+  });
+});
+describe("sendEventCertificateViewedDetailed", () => {
+  const mockGA = jest.fn();
+  // eslint-disable-next-line jest/no-hooks
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore dont care about ts here
+    window.ga = mockGA;
+  });
+
+  // eslint-disable-next-line jest/no-hooks
+  afterEach(() => {
+    delete window.ga;
+    mockGA.mockReset();
+  });
+
+  describe("when is in the registry", () => {
+    it("should use document store to retrieve registry information", () => {
+      const issuer: v2.Issuer = {
+        documentStore: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+        name: "aaa",
+        identityProof: {
+          location: "aa.com",
+          type: v2.IdentityProofType.DNSTxt,
+        },
+      };
+      const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+      sendEventCertificateViewedDetailed({ issuer, certificateData });
+      expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+      expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+      expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+      expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
+      expect(mockGA.mock.calls[0][4]).toStrictEqual(
+        '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
+      );
+      expect(mockGA.mock.calls[0][5]).toBeUndefined();
+      expect(mockGA.mock.calls[0][6]).toStrictEqual({
+        nonInteraction: true,
+        dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+        dimension2: "id1",
+        dimension3: "cert name",
+        dimension4: "a date",
+        dimension5: "Government Technology Agency of Singapore (GovTech)",
+        dimension6: "govtech-registry",
+      });
+    });
+    it("should use certificate store to retrieve registry information", () => {
+      const issuer: v2.Issuer = {
+        certificateStore: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+        name: "aaa",
+        identityProof: {
+          location: "aa.com",
+          type: v2.IdentityProofType.DNSTxt,
+        },
+      };
+      const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+      sendEventCertificateViewedDetailed({ issuer, certificateData });
+      expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+      expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+      expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+      expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
+      expect(mockGA.mock.calls[0][4]).toStrictEqual(
+        '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
+      );
+      expect(mockGA.mock.calls[0][5]).toBeUndefined();
+      expect(mockGA.mock.calls[0][6]).toStrictEqual({
+        nonInteraction: true,
+        dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+        dimension2: "id1",
+        dimension3: "cert name",
+        dimension4: "a date",
+        dimension5: "Government Technology Agency of Singapore (GovTech)",
+        dimension6: "govtech-registry",
+      });
+    });
+    it("should use token registry to retrieve registry information", () => {
+      const issuer: v2.Issuer = {
+        tokenRegistry: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
+        name: "aaa",
+        identityProof: {
+          location: "aa.com",
+          type: v2.IdentityProofType.DNSTxt,
+        },
+      };
+      const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+      sendEventCertificateViewedDetailed({ issuer, certificateData });
+      expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+      expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+      expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+      expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Nanyang Polytechnic");
+      expect(mockGA.mock.calls[0][4]).toStrictEqual(
+        '"store":"0x5CA3b9daC85DA4DE4030e59C1a0248004209e348";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Nanyang Polytechnic";"issuer_id":"nyp-registry"'
+      );
+      expect(mockGA.mock.calls[0][5]).toBeUndefined();
+      expect(mockGA.mock.calls[0][6]).toStrictEqual({
+        nonInteraction: true,
+        dimension1: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
+        dimension2: "id1",
+        dimension3: "cert name",
+        dimension4: "a date",
+        dimension5: "Nanyang Polytechnic",
+        dimension6: "nyp-registry",
+      });
+    });
+    describe("when is not in the registry", () => {
+      it("should use identity proof to display issuer information", () => {
+        const issuer: v2.Issuer = {
+          documentStore: "0xabcdef",
+          name: "aaa",
+          identityProof: {
+            location: "aa.com",
+            type: v2.IdentityProofType.DNSTxt,
+          },
+        };
+        const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+        sendEventCertificateViewedDetailed({ issuer, certificateData });
+        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - aa.com");
+        expect(mockGA.mock.calls[0][4]).toStrictEqual(
+          '"store":"0xabcdef";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"aa.com"'
+        );
+        expect(mockGA.mock.calls[0][5]).toBeUndefined();
+        expect(mockGA.mock.calls[0][6]).toStrictEqual({
+          nonInteraction: true,
+          dimension1: "0xabcdef",
+          dimension2: "id1",
+          dimension3: "cert name",
+          dimension4: "a date",
+          dimension5: "aa.com",
+          dimension6: null,
+        });
+      });
+    });
   });
 });

--- a/src/components/Analytics/index.ts
+++ b/src/components/Analytics/index.ts
@@ -1,3 +1,5 @@
+import { v2 } from "@govtechsg/open-attestation";
+import registry from "../../../public/static/registry.json";
 import { getLogger } from "../../utils/logger";
 
 const { trace } = getLogger("components:Analytics:");
@@ -8,6 +10,7 @@ interface Event {
   action: string;
   value?: string | number;
   label?: string;
+  options?: UniversalAnalytics.FieldsObject;
 }
 
 export const validateEvent = ({ category, action, value }: Event): void => {
@@ -22,11 +25,55 @@ export const stringifyEvent = ({ category, action, label, value }: Event): strin
 export const analyticsEvent = (window: Partial<Window> | undefined, event: Event): void => {
   validateEvent(event);
   if (typeof window !== "undefined" && typeof window.ga !== "undefined") {
-    const { category, action, label, value } = event;
+    const { category, action, label, value, options = undefined } = event;
     trace(stringifyEvent(event));
-    return window.ga("send", "event", category, action, label, value);
+    return window.ga("send", "event", category, action, label, value, options);
   }
   traceDev(stringifyEvent(event));
 };
 
-export default analyticsEvent;
+export const sendEventCertificateViewedDetailed = ({
+  issuer,
+  certificateData,
+}: {
+  issuer: v2.Issuer;
+  certificateData: { id?: string; name?: string; issuedOn?: string };
+}): void => {
+  let label = "";
+  let issuerName = "";
+
+  const separator = ";";
+  const store = issuer.certificateStore || issuer.documentStore || issuer.tokenRegistry;
+  const id = certificateData ? certificateData.id : "";
+  const name = certificateData ? certificateData.name : "";
+  const issuedOn = certificateData ? certificateData.issuedOn : "";
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore ignoring because typescript complain the key cant be undefined and there is no match between string type and keyof typeof registry.issuers
+  const registryIssuer = registry.issuers[store];
+
+  if (registryIssuer) {
+    issuerName = registryIssuer.name;
+    label = `"store":"${store}"${separator}"document_id":"${id}"${separator}"name":"${name}"${separator}"issued_on":"${issuedOn}"${separator}"issuer_name":"${
+      registryIssuer.name || ""
+    }"${separator}"issuer_id":"${registryIssuer.id || ""}"`;
+  } else if (issuer.identityProof) {
+    issuerName = issuer.identityProof.location;
+    label = `"store":"${store}"${separator}"document_id":"${id}"${separator}"name":"${name}"${separator}"issued_on":"${issuedOn}"${separator}"issuer_name":"${issuer.identityProof.location}"`;
+  } else {
+    label = "Something went wrong, please check the analytics code of sendEventCertificateViewedDetailed";
+  }
+  analyticsEvent(window, {
+    category: "CERTIFICATE_DETAILS",
+    action: `VIEWED - ${issuerName}`,
+    label,
+    options: {
+      nonInteraction: true,
+      dimension1: store,
+      dimension2: id,
+      dimension3: name,
+      dimension4: issuedOn,
+      dimension5: issuerName,
+      dimension6: registryIssuer?.id ?? null,
+    },
+  });
+};

--- a/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.tsx
+++ b/src/components/DecentralisedTemplateRenderer/DecentralisedRenderer.tsx
@@ -1,8 +1,8 @@
 import { FrameConnector, LegacyHostActions } from "@govtechsg/decentralized-renderer-react-components";
-import { getData, obfuscateDocument, utils, WrappedDocument } from "@govtechsg/open-attestation";
+import { getData, obfuscateDocument, utils, WrappedDocument, v2 } from "@govtechsg/open-attestation";
 import React, { Ref, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { LEGACY_OPENCERTS_RENDERER } from "../../config";
-import { analyticsEvent } from "../Analytics";
+import { analyticsEvent, sendEventCertificateViewedDetailed } from "../Analytics";
 import MultiTabs from "../MultiTabs";
 import styles from "./decentralisedRenderer.module.scss";
 
@@ -69,6 +69,10 @@ const DecentralisedRenderer: React.FunctionComponent<DecentralisedRendererProps>
       category: "CERTIFICATE_VIEWED",
       action: Array.isArray(storeAddresses) ? storeAddresses.join(",") : storeAddresses,
       label: certificateData ? certificateData.id : null,
+    });
+
+    certificateData.issuers.forEach((issuer: v2.Issuer) => {
+      sendEventCertificateViewedDetailed({ issuer, certificateData });
     });
   }, [rawDocument]);
 

--- a/src/sagas/certificate.test.ts
+++ b/src/sagas/certificate.test.ts
@@ -143,7 +143,8 @@ describe("sagas/certificate", () => {
         "CERTIFICATE_ERROR",
         "storeAdd1,storeAdd2",
         "certificate-id",
-        1337
+        1337,
+        undefined
       );
     });
 


### PR DESCRIPTION
In light of the following pivotal stories:
- https://www.pivotaltracker.com/story/show/172668387
- https://www.pivotaltracker.com/story/show/172428443

The MR adds the following analytic:
- category: "CATEGORY"
- action: "VIEWED"
- label:
  - store: document store or certificate store
  - document_id: id of the document stored in document.data.id (cleaned)
  - name: name of the document stored in document.data.name (cleaned)
  - issued_on: name of the document stored in document.data.issuedOn (cleaned)
  - issuer_name: name of the issuer, if the issuer is in registry, other the value stored in document.issuer.identityProof.location (cleaned)
  - issuer_id: id of the issuer, if the issuer is in registry

the value of label is a string where each element takes the form of key:value, separated by space, as suggested by https://stackoverflow.com/questions/11165184/is-there-any-way-for-google-analytics-to-track-multiple-event-parameters-like-mi

Getting statistics about the number of issuers and others might not be possible directly within GA, however it's possible to export events and then process the data to get the desired statistics :)