### PR TITLE
fix: encode opencert data on download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8072,6 +8072,12 @@
         "repeating": "^2.0.0"
       }
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -8196,6 +8202,15 @@
       "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "downloads-folder": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/downloads-folder/-/downloads-folder-1.0.4.tgz",
+      "integrity": "sha512-LayeWBERNZu7zEaGl69vZ2/DFXwA4lS/0X+PhB5OK/2jptOp1axOw/YtP980sB050kGg/IaCp6iWXovP0IJ0Zw==",
+      "dev": true,
+      "requires": {
+        "registry-js": "^1.9.0"
       }
     },
     "duplexer": {
@@ -9367,6 +9382,12 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
+    },
     "expect": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-26.0.1.tgz",
@@ -10022,6 +10043,12 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -10177,6 +10204,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -13978,6 +14011,12 @@
         "minimist": "0.0.8"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -14062,6 +14101,12 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
     },
     "native-url": {
       "version": "0.3.1",
@@ -14338,6 +14383,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-abi": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
+      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "node-ensure": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
@@ -14516,6 +14570,12 @@
           "dev": true
         }
       }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
     },
     "nopt": {
       "version": "1.0.10",
@@ -15901,6 +15961,37 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "prebuild-install": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.4.tgz",
+      "integrity": "sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16587,6 +16678,16 @@
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
+      }
+    },
+    "registry-js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/registry-js/-/registry-js-1.9.0.tgz",
+      "integrity": "sha512-0jI9iHxcfHvUSqYtfCc3oshbMQ3VqVLqvUD59Jjgoo+dsHNeJWBWXnOxRw2ZgFcNfdOmyPU9ClhKSDS9OvodBA==",
+      "dev": true,
+      "requires": {
+        "nan": "^2.10.0",
+        "prebuild-install": "^5.2.4"
       }
     },
     "registry-url": {
@@ -17341,6 +17442,40 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true
+        }
+      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -18497,6 +18632,54 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "term-size": {
       "version": "2.2.0",
@@ -20611,6 +20794,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
     "which-promise": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4374,6 +4374,16 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -6204,6 +6214,46 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
@@ -7270,6 +7320,12 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -8042,6 +8098,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
@@ -10164,6 +10226,44 @@
       "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
       "dev": true
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -10385,6 +10485,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -14068,8 +14174,7 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanoid": {
       "version": "1.3.4",
@@ -14637,6 +14742,18 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -18633,16 +18750,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
-    "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
-    },
     "tar-fs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
@@ -20832,6 +20939,42 @@
           "dev": true,
           "requires": {
             "pinkie": "^1.0.0"
+          }
+        }
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "cross-env": "^7.0.2",
+    "downloads-folder": "^1.0.4",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^6.8.0",

--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -115,7 +115,6 @@ export const CertificateViewer: React.FunctionComponent<CertificateViewerProps> 
                         download={`${props.certificate.id}.opencert`}
                         target="_black"
                         href={`data:text/plain;,${encodeURIComponent(JSON.stringify(props.document, null, 2))}`}
-                        id="download-link"
                       >
                         <button id="btn-download" className={styles["send-btn"]} title="Download">
                           <i className="fas fa-file-download" style={{ fontSize: "1.5rem" }} />

--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -114,7 +114,8 @@ export const CertificateViewer: React.FunctionComponent<CertificateViewerProps> 
                       <a
                         download={`${props.certificate.id}.opencert`}
                         target="_black"
-                        href={`data:text/plain;,${JSON.stringify(props.document, null, 2)}`}
+                        href={`data:text/plain;,${encodeURIComponent(JSON.stringify(props.document, null, 2))}`}
+                        id="download-link"
                       >
                         <button id="btn-download" className={styles["send-btn"]} title="Download">
                           <i className="fas fa-file-download" style={{ fontSize: "1.5rem" }} />

--- a/src/components/tests/download-certificate.spec.js
+++ b/src/components/tests/download-certificate.spec.js
@@ -1,3 +1,5 @@
+import fs from "fs";
+import downloadsFolder from "downloads-folder";
 import { Selector } from "testcafe";
 
 fixture("Download Certificate").page`http://localhost:3000`;
@@ -7,7 +9,8 @@ const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
 const CertificateStatusBanner = Selector("#status-banner-container");
-const DownloadLink = Selector("#download-link");
+const DownloadLink = Selector("a").withAttribute("download");
+const DownloadButton = Selector("#btn-download");
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
@@ -16,16 +19,14 @@ test("Sample document with no special characters is downloaded correctly", async
   await t.setFilesToUpload("input[type=file]", [Document]);
 
   await validateTextContent(t, StatusButton, ["Certificate issued by EXAMPLE.OPENATTESTATION.COM"]);
-  
-//   await t.click(DownloadLink).expect();
 
-//   await t.switchToIframe(IframeBlock);
+  const fileName = await DownloadLink.getAttribute("download");
+  const filePath = `${downloadsFolder()}\\${fileName}`;
+  await t.click(DownloadButton);
+  await t.wait(5000);
+  await t.expect(fs.exists(filePath)).eql(true);
+  console.log(filePath);
 
-//   await validateTextContent(t, SampleTemplate, [
-//     "Name & Address of Shipping Agent/Freight Forwarder",
-//     "CERTIFICATE OF NON-MANIPULATION",
-//     "DEMO JOHN TAN",
-//     "Certification by Singapore Customs",
-//     "AQSIQ170923130",
-//   ]);
+  await fs.readFile(filePath);
+  // await t.expect(fs.readFileSync(filePath)).eql(Document);
 });

--- a/src/components/tests/download-certificate.spec.js
+++ b/src/components/tests/download-certificate.spec.js
@@ -1,0 +1,31 @@
+import { Selector } from "testcafe";
+
+fixture("Download Certificate").page`http://localhost:3000`;
+
+const Document = "./fixture/sample-dns-verified.json";
+const IframeBlock = Selector("#iframe");
+const SampleTemplate = Selector("#root");
+const StatusButton = Selector("#certificate-status");
+const CertificateStatusBanner = Selector("#status-banner-container");
+const DownloadLink = Selector("#download-link");
+
+const validateTextContent = async (t, component, texts) =>
+  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
+
+test("Sample document with no special characters is downloaded correctly", async (t) => {
+  await t.setFilesToUpload("input[type=file]", [Document]);
+
+  await validateTextContent(t, StatusButton, ["Certificate issued by EXAMPLE.OPENATTESTATION.COM"]);
+  
+//   await t.click(DownloadLink).expect();
+
+//   await t.switchToIframe(IframeBlock);
+
+//   await validateTextContent(t, SampleTemplate, [
+//     "Name & Address of Shipping Agent/Freight Forwarder",
+//     "CERTIFICATE OF NON-MANIPULATION",
+//     "DEMO JOHN TAN",
+//     "Certification by Singapore Customs",
+//     "AQSIQ170923130",
+//   ]);
+});

--- a/src/components/tests/download-certificate.spec.js
+++ b/src/components/tests/download-certificate.spec.js
@@ -1,32 +1,54 @@
-import fs from "fs";
+import { existsSync, readFileSync, unlinkSync } from "fs";
 import downloadsFolder from "downloads-folder";
 import { Selector } from "testcafe";
+import TestDocument1 from "./fixture/sample-dns-verified.json";
+import TestDocument2 from "./fixture/sample-dns-verified-special-characters.json";
 
 fixture("Download Certificate").page`http://localhost:3000`;
 
-const Document = "./fixture/sample-dns-verified.json";
-const IframeBlock = Selector("#iframe");
-const SampleTemplate = Selector("#root");
+const Document1 = "./fixture/sample-dns-verified.json";
+const Document2 = "./fixture/sample-dns-verified-special-characters.json";
 const StatusButton = Selector("#certificate-status");
-const CertificateStatusBanner = Selector("#status-banner-container");
 const DownloadLink = Selector("a").withAttribute("download");
 const DownloadButton = Selector("#btn-download");
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
-test("Sample document with no special characters is downloaded correctly", async (t) => {
-  await t.setFilesToUpload("input[type=file]", [Document]);
+test("Sample document is downloaded correctly", async (t) => {
+  await t.setFilesToUpload("input[type=file]", [Document1]);
 
   await validateTextContent(t, StatusButton, ["Certificate issued by EXAMPLE.OPENATTESTATION.COM"]);
 
+  // Simulate an OpenCert file download
   const fileName = await DownloadLink.getAttribute("download");
   const filePath = `${downloadsFolder()}\\${fileName}`;
   await t.click(DownloadButton);
   await t.wait(5000);
-  await t.expect(fs.exists(filePath)).eql(true);
-  console.log(filePath);
+  await t.expect(existsSync(filePath)).eql(true);
 
-  await fs.readFile(filePath);
-  // await t.expect(fs.readFileSync(filePath)).eql(Document);
+  // We expect the contents of the input to match the downloaded file
+  await t.expect(JSON.parse(readFileSync(filePath, "utf8"))).eql(TestDocument1);
+
+  // Clean up
+  await unlinkSync(filePath);
+});
+
+test("Sample document with special characters is downloaded correctly", async (t) => {
+  await t.setFilesToUpload("input[type=file]", [Document2]);
+
+  await validateTextContent(t, StatusButton, ["Certificate issued by EXAMPLE.OPENATTESTATION.COM"]);
+
+  // Simulate an OpenCert file download
+  const fileName = await DownloadLink.getAttribute("download");
+  const filePath = `${downloadsFolder()}\\${fileName}`;
+  await t.click(DownloadButton);
+  await t.wait(5000);
+  await t.expect(existsSync(filePath)).eql(true);
+
+  // We expect the contents of the input to match the downloaded file
+  await t.expect(JSON.parse(readFileSync(filePath, "utf8"))).eql(TestDocument2);
+
+  // Clean up
+  await unlinkSync(filePath);
 });

--- a/src/components/tests/fixture/sample-dns-verified-special-characters.json
+++ b/src/components/tests/fixture/sample-dns-verified-special-characters.json
@@ -1,0 +1,66 @@
+{
+  "schema": "tradetrust/v1.0",
+  "data": {
+    "id": "309eb6b0-6cf8-4024-8d28-89ee040f1ba5:string:SGCNM21566326",
+    "$template": {
+      "name": "60050eec-8197-4b59-8a97-9ecb89be2dc5:string:CERTIFICATE_OF_NON_MANIPULATION",
+      "type": "cc320a0f-278f-47c8-80d2-65c5ad43af6c:string:EMBEDDED_RENDERER",
+      "url": "5eaa4eb2-db56-4112-9564-98d10b4ac12b:string:https://demo-cnm.openattestation.com"
+    },
+    "issuers": [
+      {
+        "name": "41110dd9-ed3b-4b0d-bbc0-0f80b920340a:string:DEMO STORE",
+        "documentStore": "9360be40-5aab-4925-9954-133479534034:string:0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+        "identityProof": {
+          "type": "b6de3f4c-ffff-4514-8aa7-ad73953247f1:string:DNS-TXT",
+          "location": "cee8ba67-bae8-47ea-89af-0ad1351381a0:string:example.openattestation.com"
+        }
+      }
+    ],
+    "recipient": {
+      "name": "70376470-740f-41b7-baf6-d15e1bb6e08d:string:SG FREIGHT",
+      "address": {
+        "street": "a3a839ed-1c8f-41a8-aa50-419455a6f696:string:101 ORCHARD ROAD",
+        "country": "d79dc412-502a-49d8-aeae-a627389c14c0:string:SINGAPORE"
+      }
+    },
+    "consignment": {
+      "description": "856c4bbd-5f5f-4d39-9223-a510c8436fc7:string:18000 CARTONS OF RED WINE 🍷",
+      "quantity": {
+        "value": "9de3cea7-b59a-4c31-bb8f-09b517539eaa:number:5000",
+        "unit": "8ed03d72-ad97-410b-92f9-a0a6b746db17:string:LITRES"
+      },
+      "countryOfOrigin": "96aa609a-74ee-451a-acd4-ea92d0024ac9:string:AUSTRALIA",
+      "outwardBillNo": "24162a60-9c16-4c61-8dea-27bc21ddf107:string:AQSIQ170923131",
+      "dateOfDischarge": "d5ea23fb-03fc-4f0c-ae29-0444c67ef83d:string:2020-05-26",
+      "dateOfDeparture": "7e2dadf0-064a-4e2c-a596-f78604eeda08:string:2020-05-30",
+      "countryOfFinalDestination": "45597259-e6c1-4767-9919-ff84003720d5:string:CHINA",
+      "outgoingVehicleNo": "2afee32d-3b4d-4296-a913-ccf47ef0fe78:string:COSCO JAPAN 074E/30-JAN",
+      "someRandomTestData": [
+        "7ed101b4-b5c0-4808-90fd-2df531d800cb:string:This text block has some HTML special characters :@+.-$%^&*",
+        "554c8b08-9428-4eae-b988-ee4eb64c5530:string:foo://example.com:8042/over/there?name=ferret#nose",
+        "17a58ce9-f262-43b6-b3fa-af53e938f632:string:urn:example:animal:ferret:nose",
+        "08827440-0386-4cf7-a1f2-9bd400381488:string:区块链"
+      ]
+    },
+    "declaration": {
+      "name": "34d5507d-bc77-45f9-ac15-70ffd6d8115e:string:PETER LEE",
+      "designation": "a92dff45-c87f-4312-85f5-2d76efaa0c20:string:SHIPPING MANAGER",
+      "date": "2018c7dd-b310-45d7-a54f-3ee4b230bcb1:string:2020-05-28"
+    },
+    "certification": {
+      "name": "1ec3bac8-e090-4163-b705-a259350ec086:string:DEMO JOHN TAN",
+      "designation": "078630b0-b44b-4356-ac4d-d15e23f4ee21:string:DEMO",
+      "date": "d9f62c8c-2c23-49b7-be6f-524d70e6c14c:string:2020-05-28"
+    }
+  },
+  "privacy": {
+    "obfuscatedData": []
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "db18db32ca67785246af5918671b9351bd50681bd238135acbdf4da037a6f429",
+    "proof": [],
+    "merkleRoot": "db18db32ca67785246af5918671b9351bd50681bd238135acbdf4da037a6f429"
+  }
+}


### PR DESCRIPTION
Issue:

- When downloading an OpenCert that contains special characters e.g. `#`, the data will be disappear. Most likely cos the browser thinks it's a fragment identifier and drops everything after.

Steps to reproduce:

1. Visit https://go.jiajian.me/mrdc-cert
1. Click on the Download button
1. Open up the downloaded OpenCert, and you should see the data being cut off (the original text contained `C#` so everything after `#` is dropped)

In this MR,

- Added `encodeURIComponent` to the download link
  - To test, visit [this link](https://dev.opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://raw.githubusercontent.com/OpenCerts/opencerts-website/1615ad54f6135a4ba3b92316ad6e8075042848fa/src/components/tests/fixture/sample-dns-verified-special-characters.json%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}) and you should be able to download it. Some special characters are not visible on the renderer as it's embedded in the `data.consignment.someRandomTestData` key.
- Added e2e tests to test for document downloads with and without special characters (i.e. emojis, special characters, Chinese)