### PR TITLE
chore: check os for integration test

### DIFF
--- a/scripts/integration-headless.sh
+++ b/scripts/integration-headless.sh
@@ -1,3 +1,5 @@
-sudo apt-get install -y xdg-user-dirs && \
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sudo apt-get install -y xdg-user-dirs
+fi
 npm run build:static && \
 npm run integration:headless -- --app "npm run serve-static"


### PR DESCRIPTION
Reason: There's no need to install `xdg-user-dir` as it's only for *nix-based OS, hence I added the OS check.

Recap: The `apt-get` was previously added to support the `downloads-folder` plugin for our integration test.