### PR TITLE
feat: error reporting in Google Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     ]
   },
   "prettier": {
-    "printWidth": 120
+    "printWidth": 120,
+    "endOfLine": "auto"
   }
 }

--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     ]
   },
   "prettier": {
-    "printWidth": 120,
-    "endOfLine": "auto"
+    "printWidth": 120
   }
 }

--- a/src/components/Analytics/analytics.test.ts
+++ b/src/components/Analytics/analytics.test.ts
@@ -26,8 +26,7 @@ describe("stringifyEvent", () => {
 describe("validateEvent", () => {
   it("throws if category is missing", () => {
     expect(() =>
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore we expect this error to be thrown
+      // @ts-expect-error we expect this error to be thrown
       validateEvent({
         label: "LABEL",
       })
@@ -36,8 +35,7 @@ describe("validateEvent", () => {
 
   it("throws if action is missing", () => {
     expect(() =>
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore we expect this error to be thrown
+      // @ts-expect-error we expect this error to be thrown
       validateEvent({
         category: "CATEGORY",
       })
@@ -78,8 +76,6 @@ describe("event", () => {
 
   it("sends and log ga event if window.ga is present", () => {
     const win = { ga: jest.fn() };
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
     analyticsEvent(win, evt);
     expect(win.ga).toHaveBeenCalledWith("send", "event", "TEST_CATEGORY", "TEST_ACTION", "TEST_LABEL", 2, undefined);
   });
@@ -87,8 +83,6 @@ describe("event", () => {
   it("throws if there is a validation error", () => {
     const win = { ga: jest.fn() };
     const errEvt = { ...evt, value: "STRING" };
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
     expect(() => analyticsEvent(win, errEvt)).toThrow("Value must be a number");
   });
 });
@@ -96,15 +90,13 @@ describe("event", () => {
 describe("analytics*", () => {
   // eslint-disable-next-line jest/no-hooks
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
+    // @ts-expect-error
     // eslint-disable-next-line jest/prefer-spy-on
     window.ga = jest.fn();
   });
   // eslint-disable-next-line jest/no-hooks
   afterEach(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
+    // @ts-expect-error
     // eslint-disable-next-line jest/prefer-spy-on
     window.ga = undefined; // This vs. delete window.ga, mockGA.mockReset()?
   });
@@ -113,8 +105,7 @@ describe("analytics*", () => {
     const mockGA = jest.fn();
     // eslint-disable-next-line jest/no-hooks
     beforeEach(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore dont care about ts here
+      // @ts-expect-error dont care about ts here
       window.ga = mockGA;
     });
 

--- a/src/components/Analytics/analytics.test.ts
+++ b/src/components/Analytics/analytics.test.ts
@@ -92,107 +92,125 @@ describe("event", () => {
     expect(() => analyticsEvent(win, errEvt)).toThrow("Value must be a number");
   });
 });
-describe("sendEventCertificateViewedDetailed", () => {
-  const mockGA = jest.fn();
+
+describe("analytics*", () => {
   // eslint-disable-next-line jest/no-hooks
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore dont care about ts here
-    window.ga = mockGA;
+    // @ts-ignore
+    // eslint-disable-next-line jest/prefer-spy-on
+    window.ga = jest.fn();
   });
-
   // eslint-disable-next-line jest/no-hooks
   afterEach(() => {
-    delete window.ga;
-    mockGA.mockReset();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    // eslint-disable-next-line jest/prefer-spy-on
+    window.ga = undefined; // This vs. delete window.ga, mockGA.mockReset()?
   });
 
-  describe("when is in the registry", () => {
-    it("should use document store to retrieve registry information", () => {
-      const issuer: v2.Issuer = {
-        documentStore: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-        name: "aaa",
-        identityProof: {
-          location: "aa.com",
-          type: v2.IdentityProofType.DNSTxt,
-        },
-      };
-      const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
-      sendEventCertificateViewedDetailed({ issuer, certificateData });
-      expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-      expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-      expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-      expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
-      expect(mockGA.mock.calls[0][4]).toStrictEqual(
-        '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
-      );
-      expect(mockGA.mock.calls[0][5]).toBeUndefined();
-      expect(mockGA.mock.calls[0][6]).toStrictEqual({
-        nonInteraction: true,
-        dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-        dimension2: "id1",
-        dimension3: "cert name",
-        dimension4: "a date",
-        dimension5: "Government Technology Agency of Singapore (GovTech)",
-        dimension6: "govtech-registry",
-      });
+  describe("sendEventCertificateViewedDetailed", () => {
+    const mockGA = jest.fn();
+    // eslint-disable-next-line jest/no-hooks
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore dont care about ts here
+      window.ga = mockGA;
     });
-    it("should use certificate store to retrieve registry information", () => {
-      const issuer: v2.Issuer = {
-        certificateStore: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-        name: "aaa",
-        identityProof: {
-          location: "aa.com",
-          type: v2.IdentityProofType.DNSTxt,
-        },
-      };
-      const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
-      sendEventCertificateViewedDetailed({ issuer, certificateData });
-      expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-      expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-      expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-      expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
-      expect(mockGA.mock.calls[0][4]).toStrictEqual(
-        '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
-      );
-      expect(mockGA.mock.calls[0][5]).toBeUndefined();
-      expect(mockGA.mock.calls[0][6]).toStrictEqual({
-        nonInteraction: true,
-        dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-        dimension2: "id1",
-        dimension3: "cert name",
-        dimension4: "a date",
-        dimension5: "Government Technology Agency of Singapore (GovTech)",
-        dimension6: "govtech-registry",
-      });
+
+    // eslint-disable-next-line jest/no-hooks
+    afterEach(() => {
+      delete window.ga;
+      mockGA.mockReset();
     });
-    it("should use token registry to retrieve registry information", () => {
-      const issuer: v2.Issuer = {
-        tokenRegistry: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
-        name: "aaa",
-        identityProof: {
-          location: "aa.com",
-          type: v2.IdentityProofType.DNSTxt,
-        },
-      };
-      const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
-      sendEventCertificateViewedDetailed({ issuer, certificateData });
-      expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-      expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-      expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-      expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Nanyang Polytechnic");
-      expect(mockGA.mock.calls[0][4]).toStrictEqual(
-        '"store":"0x5CA3b9daC85DA4DE4030e59C1a0248004209e348";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Nanyang Polytechnic";"issuer_id":"nyp-registry"'
-      );
-      expect(mockGA.mock.calls[0][5]).toBeUndefined();
-      expect(mockGA.mock.calls[0][6]).toStrictEqual({
-        nonInteraction: true,
-        dimension1: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
-        dimension2: "id1",
-        dimension3: "cert name",
-        dimension4: "a date",
-        dimension5: "Nanyang Polytechnic",
-        dimension6: "nyp-registry",
+
+    describe("when is in the registry", () => {
+      it("should use document store to retrieve registry information", () => {
+        const issuer: v2.Issuer = {
+          documentStore: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+          name: "aaa",
+          identityProof: {
+            location: "aa.com",
+            type: v2.IdentityProofType.DNSTxt,
+          },
+        };
+        const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+        sendEventCertificateViewedDetailed({ issuer, certificateData });
+        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
+        expect(mockGA.mock.calls[0][4]).toStrictEqual(
+          '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
+        );
+        expect(mockGA.mock.calls[0][5]).toBeUndefined();
+        expect(mockGA.mock.calls[0][6]).toStrictEqual({
+          nonInteraction: true,
+          dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+          dimension2: "id1",
+          dimension3: "cert name",
+          dimension4: "a date",
+          dimension5: "Government Technology Agency of Singapore (GovTech)",
+          dimension6: "govtech-registry",
+        });
+      });
+      it("should use certificate store to retrieve registry information", () => {
+        const issuer: v2.Issuer = {
+          certificateStore: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+          name: "aaa",
+          identityProof: {
+            location: "aa.com",
+            type: v2.IdentityProofType.DNSTxt,
+          },
+        };
+        const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+        sendEventCertificateViewedDetailed({ issuer, certificateData });
+        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
+        expect(mockGA.mock.calls[0][4]).toStrictEqual(
+          '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
+        );
+        expect(mockGA.mock.calls[0][5]).toBeUndefined();
+        expect(mockGA.mock.calls[0][6]).toStrictEqual({
+          nonInteraction: true,
+          dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+          dimension2: "id1",
+          dimension3: "cert name",
+          dimension4: "a date",
+          dimension5: "Government Technology Agency of Singapore (GovTech)",
+          dimension6: "govtech-registry",
+        });
+      });
+      it("should use token registry to retrieve registry information", () => {
+        const issuer: v2.Issuer = {
+          tokenRegistry: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
+          name: "aaa",
+          identityProof: {
+            location: "aa.com",
+            type: v2.IdentityProofType.DNSTxt,
+          },
+        };
+        const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
+        sendEventCertificateViewedDetailed({ issuer, certificateData });
+        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
+        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
+        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
+        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Nanyang Polytechnic");
+        expect(mockGA.mock.calls[0][4]).toStrictEqual(
+          '"store":"0x5CA3b9daC85DA4DE4030e59C1a0248004209e348";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Nanyang Polytechnic";"issuer_id":"nyp-registry"'
+        );
+        expect(mockGA.mock.calls[0][5]).toBeUndefined();
+        expect(mockGA.mock.calls[0][6]).toStrictEqual({
+          nonInteraction: true,
+          dimension1: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
+          dimension2: "id1",
+          dimension3: "cert name",
+          dimension4: "a date",
+          dimension5: "Nanyang Polytechnic",
+          dimension6: "nyp-registry",
+        });
       });
     });
     describe("when is not in the registry", () => {
@@ -227,23 +245,7 @@ describe("sendEventCertificateViewedDetailed", () => {
       });
     });
   });
-});
 
-describe("analytics*", () => {
-  // eslint-disable-next-line jest/no-hooks
-  beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    // eslint-disable-next-line jest/prefer-spy-on
-    window.ga = jest.fn();
-  });
-  // eslint-disable-next-line jest/no-hooks
-  afterEach(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    // eslint-disable-next-line jest/prefer-spy-on
-    window.ga = undefined;
-  });
   describe("triggerErrorLogging", () => {
     it("should send cert details (certificateStore) and errors to Google Analytics", () => {
       const certificate: WrappedDocument = {
@@ -283,26 +285,8 @@ describe("analytics*", () => {
         signature: {
           type: "SHA3MerkleProof",
           targetHash: "64f8058107cda314c437a1d22fd8906fdf6e08bde1d50293e0806c1dcf29f49b",
-          proof: [
-            "a2c4ded0a3f54caae9a9cff70138625e095a5d25982453f3b3f01cc739dd5394",
-            "a96b8bc2d30004d9c4fc06ba543531e86e4a6663358b44515ddf3e13c6661363",
-            "e2b59a7591b133875857e66238ffd82ab334352dc30ad92072b55bfbbac8aeb3",
-            "5e883a0758853e1ff4beb418853f5581cdbede52a99413a0e2e642a9427e5d3a",
-            "7e4ff422f67dd54e7adbcd396613c882f56aed37d28a92b75464818e87b5e0c8",
-            "7e9f13fecdd301396a49205d5e4e9d4d510483de94f7ce5959705ca27a9622ac",
-            "194b54fab9fa3fea3ccb28547cea3b384309af50a9e8d60e11deb2398db3cbde",
-            "c0f4d2fe097ec81d3c52b28955fec39441fba9dcdbf444972c547b0d6b44931b",
-            "7c3a2be42b86baa300f032c3f2246ad335c80dd526acfe7435a788e6215799fe",
-            "a05cc0f6e66acb8ba0e2b3ddeac5e6c38ce01c82df0ed09b341076ae9bcd07f3",
-            "a2a7b47af15ee91dc0ac738a5bb38bfc5f6af559b5696b2cdb0d81e6a91133c0",
-            "789c3c9ae12840abb4c166b5614245bf718667d09126ea7582925be6b6e6ca6a",
-            "4bc04315fda8a6cc6355d57bb3a9c7016933104627713b58abcecaa12417b64a",
-            "d9095e8c10dc7fb060593e0c6b7e4dea832a685afd96edd661ddb48d32ca74e1",
-            "eb8b3bfae929e613e63df8e3b20770a27050cd88b3f5099c372b1649fbeacd89",
-            "d8d2bacf6182e1ffaec35c19412e84fce5a94bb5c86bd3c4ceb77c8a1692305d",
-            "5210c8d56a9ed82c4b1d9df161120b7a8c70175212459232dd418976b7fb029e",
-          ],
-          merkleRoot: "a67e656818400c059e3461b53b042e85fa4db8ceb57ae51e15e21cc15c9ad3ef",
+          proof: [],
+          merkleRoot: "64f8058107cda314c437a1d22fd8906fdf6e08bde1d50293e0806c1dcf29f49b",
         },
       };
 
@@ -360,7 +344,7 @@ describe("analytics*", () => {
                 name: "b2d4a5fc-7e0a-43ad-a224-97c21c3adb85:string:Professor Demo of all Demos",
                 designation: "5226c4c8-df28-4eed-8d9f-0cf41b09dbdb:string:Dean of Demos",
               },
-            ]
+            ],
           },
           $template: {
             name: "10af685b-06c1-49dd-92bb-af3a52fcf705:string:SMU-A-TIS-2019-4",
@@ -374,13 +358,8 @@ describe("analytics*", () => {
         signature: {
           type: "SHA3MerkleProof",
           targetHash: "64f7b1322fdb86be136a23eb65b93351bdf5128a0e5afb64019e179cb66f078b",
-          proof: [
-            "f5dab77712afd47a8b87b4b3bc685c1c6827843e38357697e52c01593ed7fb22",
-            "516794e14a69074a1437ddb972a063d04b4733ad6076fdd335f2d5bdab52ec05",
-            "74f086ebff10a10158233dbbdc207d4514f7bd8df9cbcadf4a384c1cf0de96f7",
-            "eddfd98891328db274321edc5985d839772e3bc1e481d8f7d6fa972cad7ed68f",
-          ],
-          merkleRoot: "6b5bb39220415b92c321cb981fccf6e8cdc16287d8eb2e56a2ad33f757ccfae2",
+          proof: [],
+          merkleRoot: "64f7b1322fdb86be136a23eb65b93351bdf5128a0e5afb64019e179cb66f078b",
         },
       };
 

--- a/src/components/Analytics/analytics.test.ts
+++ b/src/components/Analytics/analytics.test.ts
@@ -102,19 +102,6 @@ describe("analytics*", () => {
   });
 
   describe("sendEventCertificateViewedDetailed", () => {
-    const mockGA = jest.fn();
-    // eslint-disable-next-line jest/no-hooks
-    beforeEach(() => {
-      // @ts-expect-error dont care about ts here
-      window.ga = mockGA;
-    });
-
-    // eslint-disable-next-line jest/no-hooks
-    afterEach(() => {
-      delete window.ga;
-      mockGA.mockReset();
-    });
-
     describe("when is in the registry", () => {
       it("should use document store to retrieve registry information", () => {
         const issuer: v2.Issuer = {
@@ -127,23 +114,23 @@ describe("analytics*", () => {
         };
         const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
         sendEventCertificateViewedDetailed({ issuer, certificateData });
-        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
-        expect(mockGA.mock.calls[0][4]).toStrictEqual(
-          '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
+        expect(window.ga).toHaveBeenCalledWith(
+          "send",
+          "event",
+          "CERTIFICATE_DETAILS",
+          "VIEWED - Government Technology Agency of Singapore (GovTech)",
+          '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"',
+          undefined,
+          {
+            dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+            dimension2: "id1",
+            dimension3: "cert name",
+            dimension4: "a date",
+            dimension5: "Government Technology Agency of Singapore (GovTech)",
+            dimension6: "govtech-registry",
+            nonInteraction: true,
+          }
         );
-        expect(mockGA.mock.calls[0][5]).toBeUndefined();
-        expect(mockGA.mock.calls[0][6]).toStrictEqual({
-          nonInteraction: true,
-          dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-          dimension2: "id1",
-          dimension3: "cert name",
-          dimension4: "a date",
-          dimension5: "Government Technology Agency of Singapore (GovTech)",
-          dimension6: "govtech-registry",
-        });
       });
       it("should use certificate store to retrieve registry information", () => {
         const issuer: v2.Issuer = {
@@ -156,23 +143,23 @@ describe("analytics*", () => {
         };
         const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
         sendEventCertificateViewedDetailed({ issuer, certificateData });
-        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Government Technology Agency of Singapore (GovTech)");
-        expect(mockGA.mock.calls[0][4]).toStrictEqual(
-          '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"'
+        expect(window.ga).toHaveBeenCalledWith(
+          "send",
+          "event",
+          "CERTIFICATE_DETAILS",
+          "VIEWED - Government Technology Agency of Singapore (GovTech)",
+          '"store":"0x007d40224f6562461633ccfbaffd359ebb2fc9ba";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Government Technology Agency of Singapore (GovTech)";"issuer_id":"govtech-registry"',
+          undefined,
+          {
+            dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+            dimension2: "id1",
+            dimension3: "cert name",
+            dimension4: "a date",
+            dimension5: "Government Technology Agency of Singapore (GovTech)",
+            dimension6: "govtech-registry",
+            nonInteraction: true,
+          }
         );
-        expect(mockGA.mock.calls[0][5]).toBeUndefined();
-        expect(mockGA.mock.calls[0][6]).toStrictEqual({
-          nonInteraction: true,
-          dimension1: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-          dimension2: "id1",
-          dimension3: "cert name",
-          dimension4: "a date",
-          dimension5: "Government Technology Agency of Singapore (GovTech)",
-          dimension6: "govtech-registry",
-        });
       });
       it("should use token registry to retrieve registry information", () => {
         const issuer: v2.Issuer = {
@@ -185,23 +172,23 @@ describe("analytics*", () => {
         };
         const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
         sendEventCertificateViewedDetailed({ issuer, certificateData });
-        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - Nanyang Polytechnic");
-        expect(mockGA.mock.calls[0][4]).toStrictEqual(
-          '"store":"0x5CA3b9daC85DA4DE4030e59C1a0248004209e348";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Nanyang Polytechnic";"issuer_id":"nyp-registry"'
+        expect(window.ga).toHaveBeenCalledWith(
+          "send",
+          "event",
+          "CERTIFICATE_DETAILS",
+          "VIEWED - Nanyang Polytechnic",
+          '"store":"0x5CA3b9daC85DA4DE4030e59C1a0248004209e348";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"Nanyang Polytechnic";"issuer_id":"nyp-registry"',
+          undefined,
+          {
+            dimension1: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
+            dimension2: "id1",
+            dimension3: "cert name",
+            dimension4: "a date",
+            dimension5: "Nanyang Polytechnic",
+            dimension6: "nyp-registry",
+            nonInteraction: true,
+          }
         );
-        expect(mockGA.mock.calls[0][5]).toBeUndefined();
-        expect(mockGA.mock.calls[0][6]).toStrictEqual({
-          nonInteraction: true,
-          dimension1: "0x5CA3b9daC85DA4DE4030e59C1a0248004209e348",
-          dimension2: "id1",
-          dimension3: "cert name",
-          dimension4: "a date",
-          dimension5: "Nanyang Polytechnic",
-          dimension6: "nyp-registry",
-        });
       });
     });
     describe("when is not in the registry", () => {
@@ -216,23 +203,23 @@ describe("analytics*", () => {
         };
         const certificateData = { id: "id1", name: "cert name", issuedOn: "a date" };
         sendEventCertificateViewedDetailed({ issuer, certificateData });
-        expect(mockGA.mock.calls[0][0]).toStrictEqual("send");
-        expect(mockGA.mock.calls[0][1]).toStrictEqual("event");
-        expect(mockGA.mock.calls[0][2]).toStrictEqual("CERTIFICATE_DETAILS");
-        expect(mockGA.mock.calls[0][3]).toStrictEqual("VIEWED - aa.com");
-        expect(mockGA.mock.calls[0][4]).toStrictEqual(
-          '"store":"0xabcdef";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"aa.com"'
+        expect(window.ga).toHaveBeenCalledWith(
+          "send",
+          "event",
+          "CERTIFICATE_DETAILS",
+          "VIEWED - aa.com",
+          '"store":"0xabcdef";"document_id":"id1";"name":"cert name";"issued_on":"a date";"issuer_name":"aa.com"',
+          undefined,
+          {
+            dimension1: "0xabcdef",
+            dimension2: "id1",
+            dimension3: "cert name",
+            dimension4: "a date",
+            dimension5: "aa.com",
+            dimension6: "(not set)",
+            nonInteraction: true,
+          }
         );
-        expect(mockGA.mock.calls[0][5]).toBeUndefined();
-        expect(mockGA.mock.calls[0][6]).toStrictEqual({
-          nonInteraction: true,
-          dimension1: "0xabcdef",
-          dimension2: "id1",
-          dimension3: "cert name",
-          dimension4: "a date",
-          dimension5: "aa.com",
-          dimension6: "(not set)",
-        });
       });
     });
   });
@@ -245,11 +232,8 @@ describe("analytics*", () => {
           attainmentDate: "a6474204-94a4-499b-af95-b161ea0f6996:string:2012-12-31T23:59:00+08:00",
           transcript: [
             {
-              level: "215cba59-fc69-4799-906d-13831235d61b:string:ORDINARY",
               grade: "0312dcfb-460d-4b01-b154-676ae307f91c:string:1",
               name: "191170f2-7c47-497f-954f-09b7b4b2fc25:string:ADDITIONAL MATHEMATICS",
-              languageMedium: "02f3c2f4-207d-4106-b950-dbde85457d71:string:ENGLISH",
-              examiningAuthority: "b2511648-d512-44d6-92a2-7e9537bf2169:string:CAMBRIDGE",
             },
           ],
           $template: "87387e89-58ac-41cb-abb8-66af522dd5f5:string:sg/gov/seab/SOR_GCEO",
@@ -257,10 +241,6 @@ describe("analytics*", () => {
             "3185297a-bb47-4853-8f45-9cb60cf98608:string:SINGAPORE-CAMBRIDGE GENERAL CERTIFICATE OF EDUCATION ORDINARY LEVEL",
           recipient: {},
           id: "5dd55da3-8e32-4ee6-b23b-5c17a3395792:string:MyAwesomeCertID",
-          additionalData: {
-            certifierDesignation: "5551636b-8015-4437-8726-183ee0e030da:string:Chief Executive",
-            certifierName: "572bae48-a0e6-4410-b8cc-289791c19ffb:string:Mr Yue Lip Sin",
-          },
           issuers: [
             {
               name: "b6c56876-2a07-4efb-a56f-afdeb7ec91f2:string:SEAB",
@@ -329,14 +309,6 @@ describe("analytics*", () => {
               },
             },
           ],
-          additionalData: {
-            certSignatories: [
-              {
-                name: "b2d4a5fc-7e0a-43ad-a224-97c21c3adb85:string:Professor Demo of all Demos",
-                designation: "5226c4c8-df28-4eed-8d9f-0cf41b09dbdb:string:Dean of Demos",
-              },
-            ],
-          },
           $template: {
             name: "10af685b-06c1-49dd-92bb-af3a52fcf705:string:SMU-A-TIS-2019-4",
             type: "f81508ff-2f40-4bf5-a6ec-7b907d1a9898:string:EMBEDDED_RENDERER",

--- a/src/components/Analytics/analytics.test.ts
+++ b/src/components/Analytics/analytics.test.ts
@@ -1,5 +1,11 @@
-import { v2 } from "@govtechsg/open-attestation";
-import { analyticsEvent, sendEventCertificateViewedDetailed, stringifyEvent, validateEvent } from "./index";
+import { v2, WrappedDocument, SchemaId } from "@govtechsg/open-attestation";
+import {
+  analyticsEvent,
+  sendEventCertificateViewedDetailed,
+  stringifyEvent,
+  validateEvent,
+  triggerErrorLogging,
+} from "./index";
 
 const evt = {
   category: "TEST_CATEGORY",
@@ -219,6 +225,188 @@ describe("sendEventCertificateViewedDetailed", () => {
           dimension6: "(not set)",
         });
       });
+    });
+  });
+});
+
+describe("analytics*", () => {
+  // eslint-disable-next-line jest/no-hooks
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    // eslint-disable-next-line jest/prefer-spy-on
+    window.ga = jest.fn();
+  });
+  // eslint-disable-next-line jest/no-hooks
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    // eslint-disable-next-line jest/prefer-spy-on
+    window.ga = undefined;
+  });
+  describe("triggerErrorLogging", () => {
+    it("should send cert details (certificateStore) and errors to Google Analytics", () => {
+      const certificate: WrappedDocument = {
+        version: SchemaId.v2,
+        data: {
+          attainmentDate: "a6474204-94a4-499b-af95-b161ea0f6996:string:2012-12-31T23:59:00+08:00",
+          transcript: [
+            {
+              level: "215cba59-fc69-4799-906d-13831235d61b:string:ORDINARY",
+              grade: "0312dcfb-460d-4b01-b154-676ae307f91c:string:1",
+              name: "191170f2-7c47-497f-954f-09b7b4b2fc25:string:ADDITIONAL MATHEMATICS",
+              languageMedium: "02f3c2f4-207d-4106-b950-dbde85457d71:string:ENGLISH",
+              examiningAuthority: "b2511648-d512-44d6-92a2-7e9537bf2169:string:CAMBRIDGE",
+            },
+          ],
+          $template: "87387e89-58ac-41cb-abb8-66af522dd5f5:string:sg/gov/seab/SOR_GCEO",
+          name:
+            "3185297a-bb47-4853-8f45-9cb60cf98608:string:SINGAPORE-CAMBRIDGE GENERAL CERTIFICATE OF EDUCATION ORDINARY LEVEL",
+          recipient: {},
+          id: "5dd55da3-8e32-4ee6-b23b-5c17a3395792:string:MyAwesomeCertID",
+          additionalData: {
+            certifierDesignation: "5551636b-8015-4437-8726-183ee0e030da:string:Chief Executive",
+            certifierName: "572bae48-a0e6-4410-b8cc-289791c19ffb:string:Mr Yue Lip Sin",
+          },
+          issuers: [
+            {
+              name: "b6c56876-2a07-4efb-a56f-afdeb7ec91f2:string:SEAB",
+              certificateStore:
+                "979b437d-d7ec-4e9f-9384-f78962e1af2a:string:0xE4a94Ef9C26904A02Cd6735F7D4De1D840146a0f",
+            },
+          ],
+          issuedOn: "eaef8495-93d6-45ab-988f-5ef5785fd2f3:string:2019-09-02T18:51:14+08:00",
+        },
+        privacy: {
+          obfuscatedData: [],
+        },
+        signature: {
+          type: "SHA3MerkleProof",
+          targetHash: "64f8058107cda314c437a1d22fd8906fdf6e08bde1d50293e0806c1dcf29f49b",
+          proof: [
+            "a2c4ded0a3f54caae9a9cff70138625e095a5d25982453f3b3f01cc739dd5394",
+            "a96b8bc2d30004d9c4fc06ba543531e86e4a6663358b44515ddf3e13c6661363",
+            "e2b59a7591b133875857e66238ffd82ab334352dc30ad92072b55bfbbac8aeb3",
+            "5e883a0758853e1ff4beb418853f5581cdbede52a99413a0e2e642a9427e5d3a",
+            "7e4ff422f67dd54e7adbcd396613c882f56aed37d28a92b75464818e87b5e0c8",
+            "7e9f13fecdd301396a49205d5e4e9d4d510483de94f7ce5959705ca27a9622ac",
+            "194b54fab9fa3fea3ccb28547cea3b384309af50a9e8d60e11deb2398db3cbde",
+            "c0f4d2fe097ec81d3c52b28955fec39441fba9dcdbf444972c547b0d6b44931b",
+            "7c3a2be42b86baa300f032c3f2246ad335c80dd526acfe7435a788e6215799fe",
+            "a05cc0f6e66acb8ba0e2b3ddeac5e6c38ce01c82df0ed09b341076ae9bcd07f3",
+            "a2a7b47af15ee91dc0ac738a5bb38bfc5f6af559b5696b2cdb0d81e6a91133c0",
+            "789c3c9ae12840abb4c166b5614245bf718667d09126ea7582925be6b6e6ca6a",
+            "4bc04315fda8a6cc6355d57bb3a9c7016933104627713b58abcecaa12417b64a",
+            "d9095e8c10dc7fb060593e0c6b7e4dea832a685afd96edd661ddb48d32ca74e1",
+            "eb8b3bfae929e613e63df8e3b20770a27050cd88b3f5099c372b1649fbeacd89",
+            "d8d2bacf6182e1ffaec35c19412e84fce5a94bb5c86bd3c4ceb77c8a1692305d",
+            "5210c8d56a9ed82c4b1d9df161120b7a8c70175212459232dd418976b7fb029e",
+          ],
+          merkleRoot: "a67e656818400c059e3461b53b042e85fa4db8ceb57ae51e15e21cc15c9ad3ef",
+        },
+      };
+
+      triggerErrorLogging(certificate, [
+        "CERTIFICATE_HASH", // Document has been tampered, naughty naughty!
+        "UNISSUED_CERTIFICATE", // Document isn't issued by the given store
+        "REVOKED_CERTIFICATE", // Document has been revoked by the given store
+      ]);
+
+      expect(window.ga).toHaveBeenCalledWith(
+        "send",
+        "event",
+        "CERTIFICATE_ERROR",
+        "ERROR - Singapore Examinations and Assessment Board",
+        "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
+        undefined,
+        {
+          dimension1: "0xE4a94Ef9C26904A02Cd6735F7D4De1D840146a0f",
+          dimension2: "MyAwesomeCertID",
+          dimension3: "SINGAPORE-CAMBRIDGE GENERAL CERTIFICATE OF EDUCATION ORDINARY LEVEL",
+          dimension4: "2019-09-02T18:51:14+08:00",
+          dimension5: "Singapore Examinations and Assessment Board",
+          dimension6: "seab-registry",
+          dimension7: "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
+          nonInteraction: true,
+        }
+      );
+    });
+    it("should send cert details (documentStore/DNS-TXT) and errors to Google Analytics", () => {
+      const certificate: WrappedDocument = {
+        version: SchemaId.v2,
+        data: {
+          id: "e160ddc1-3e9f-496a-8e96-d3c0873c7561:string:MyAwesomeCertID",
+          description: "d24c312f-86b0-4446-a03d-38fb9957aefc:string:The course...",
+          name:
+            "b5fae7b2-ca9a-4ebc-a732-63f1c208263e:string:Practitioner Certificate in Personal Data Protection (Singapore)",
+          recipient: {
+            name: "93c37dd3-8416-49f8-81b7-1716d3aefa5f:string:Goi Jia Jian",
+          },
+          issuedOn: "42286912-67d2-4185-a481-2c7821131283:string:2020-04-14T08:00:00+08:00",
+          issuers: [
+            {
+              name: "90757fa9-c143-45bb-9769-bc1f266058c4:string:Demo Academy",
+              documentStore: "48030765-2463-4d83-878d-79db52b0d877:string:0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+              network: "49d75ef9-d606-4923-9492-9cf4da012a64:string:ETHEREUM",
+              identityProof: {
+                type: "0bd3fb8f-c065-4808-b128-29cc13fb1cc1:string:DNS-TXT",
+                location: "71b2f120-a613-44aa-8cf0-13ae660cdb0b:string:example.openattestation.com",
+              },
+            },
+          ],
+          additionalData: {
+            certSignatories: [
+              {
+                name: "b2d4a5fc-7e0a-43ad-a224-97c21c3adb85:string:Professor Demo of all Demos",
+                designation: "5226c4c8-df28-4eed-8d9f-0cf41b09dbdb:string:Dean of Demos",
+              },
+            ]
+          },
+          $template: {
+            name: "10af685b-06c1-49dd-92bb-af3a52fcf705:string:SMU-A-TIS-2019-4",
+            type: "f81508ff-2f40-4bf5-a6ec-7b907d1a9898:string:EMBEDDED_RENDERER",
+            url: "fe4ef2ba-e773-4ba4-ba14-c9e88bc35abe:string:https://demo-cnm.openattestation.com",
+          },
+        },
+        privacy: {
+          obfuscatedData: [],
+        },
+        signature: {
+          type: "SHA3MerkleProof",
+          targetHash: "64f7b1322fdb86be136a23eb65b93351bdf5128a0e5afb64019e179cb66f078b",
+          proof: [
+            "f5dab77712afd47a8b87b4b3bc685c1c6827843e38357697e52c01593ed7fb22",
+            "516794e14a69074a1437ddb972a063d04b4733ad6076fdd335f2d5bdab52ec05",
+            "74f086ebff10a10158233dbbdc207d4514f7bd8df9cbcadf4a384c1cf0de96f7",
+            "eddfd98891328db274321edc5985d839772e3bc1e481d8f7d6fa972cad7ed68f",
+          ],
+          merkleRoot: "6b5bb39220415b92c321cb981fccf6e8cdc16287d8eb2e56a2ad33f757ccfae2",
+        },
+      };
+
+      triggerErrorLogging(certificate, [
+        "CERTIFICATE_HASH", // Document has been tampered, naughty naughty!
+        "UNISSUED_CERTIFICATE", // Document isn't issued by the given store
+        "REVOKED_CERTIFICATE", // Document has been revoked by the given store
+      ]);
+      expect(window.ga).toHaveBeenCalledWith(
+        "send",
+        "event",
+        "CERTIFICATE_ERROR",
+        "ERROR - example.openattestation.com",
+        "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
+        undefined,
+        {
+          dimension1: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+          dimension2: "MyAwesomeCertID",
+          dimension3: "Practitioner Certificate in Personal Data Protection (Singapore)",
+          dimension4: "2020-04-14T08:00:00+08:00",
+          dimension5: "example.openattestation.com",
+          dimension6: "(not set)",
+          dimension7: "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
+          nonInteraction: true,
+        }
+      );
     });
   });
 });

--- a/src/components/Analytics/index.ts
+++ b/src/components/Analytics/index.ts
@@ -78,22 +78,37 @@ export const sendEventCertificateViewedDetailed = ({
   });
 };
 
+interface Registry {
+  [key: string]: {
+    name: string;
+    displayCard?: boolean;
+    website?: string;
+    email?: string;
+    phone?: string;
+    logo?: string;
+    id?: string;
+  };
+}
+
+// const getKeyValue = <T extends object, U extends keyof T>(obj: T) => (key: U) => obj[key];
+
 export function triggerErrorLogging(
   rawCertificate: WrappedDocument<v2.OpenAttestationDocument>,
   errors: string[]
 ): void {
-  const certificate: v2.OpenAttestationDocument = getData(rawCertificate);
+  const certificate: v2.OpenAttestationDocument & { name?: string; issuedOn?: string } = getData(rawCertificate);
 
-  const id = certificate.id;
-  const name = get(certificate, "name") ?? "";
-  const issuedOn = get(certificate, "issuedOn") ?? "";
+  const id = certificate?.id;
+  const name = certificate?.name;
+  const issuedOn = certificate?.issuedOn;
   const errorsList = errors.join(",");
 
   // If there are multiple issuers in a certificate, we send multiple events!
   certificate.issuers.forEach((issuer: v2.Issuer) => {
     const store = issuer.certificateStore ?? issuer.documentStore ?? issuer.tokenRegistry ?? "";
     let issuerName = issuer.name;
-    const registryIssuer = get(registry.issuers, store);
+    // TODO: https://stackoverflow.com/questions/53519513/in-typescript-how-to-import-json-and-dynamically-lookup-by-key
+    const registryIssuer = get(registry.issuers, store); //getKeyValue(Registry)(store);
 
     if (registryIssuer) {
       issuerName = registryIssuer.name;

--- a/src/components/Analytics/index.ts
+++ b/src/components/Analytics/index.ts
@@ -1,7 +1,7 @@
 import { v2 } from "@govtechsg/open-attestation";
+import { get } from "lodash";
 import registry from "../../../public/static/registry.json";
 import { getLogger } from "../../utils/logger";
-import { get } from "lodash";
 
 const { trace } = getLogger("components:Analytics:");
 const { trace: traceDev } = getLogger("components:Analytics(Inactive):");

--- a/src/components/Analytics/index.ts
+++ b/src/components/Analytics/index.ts
@@ -1,6 +1,7 @@
 import { v2 } from "@govtechsg/open-attestation";
 import registry from "../../../public/static/registry.json";
 import { getLogger } from "../../utils/logger";
+import { get } from "lodash";
 
 const { trace } = getLogger("components:Analytics:");
 const { trace: traceDev } = getLogger("components:Analytics(Inactive):");
@@ -47,9 +48,7 @@ export const sendEventCertificateViewedDetailed = ({
   const id = certificateData?.id ?? "";
   const name = certificateData?.name ?? "";
   const issuedOn = certificateData?.issuedOn ?? "";
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore ignoring because typescript complain the key cant be undefined and there is no match between string type and keyof typeof registry.issuers
-  const registryIssuer = registry.issuers[store];
+  const registryIssuer = get(registry.issuers, store);
 
   if (registryIssuer) {
     issuerName = registryIssuer.name;

--- a/src/sagas/certificate.test.ts
+++ b/src/sagas/certificate.test.ts
@@ -1,4 +1,7 @@
-import { OpenAttestationDocument, IdentityProofType } from "@govtechsg/open-attestation/dist/types/__generated__/schemaV2";
+import {
+  OpenAttestationDocument,
+  IdentityProofType,
+} from "@govtechsg/open-attestation/dist/types/__generated__/schemaV2";
 import { call, put, select } from "redux-saga/effects";
 import { getCertificate } from "../reducers/certificate.selectors";
 import { sendCertificate, getCertificateDetails, triggerErrorLogging } from "./certificate";

--- a/src/sagas/certificate.test.ts
+++ b/src/sagas/certificate.test.ts
@@ -119,7 +119,7 @@ describe("sagas/certificate", () => {
     });
 
     describe("triggerErrorLogging", () => {
-      it("should get cert details (certificateStore), and send it over to Google Analytics with a CSV list of errors", () => {
+      it("should send cert details (certificateStore) and errors to Google Analytics", () => {
         const analyticsGenerator = triggerErrorLogging([
           "CERTIFICATE_HASH", // Document has been tampered, naughty naughty!
           "UNISSUED_CERTIFICATE", // Document isn't issued by the given store
@@ -160,7 +160,7 @@ describe("sagas/certificate", () => {
           }
         );
       });
-      it("should get cert details (documentStore/DNS-TXT), and send it over to Google Analytics with a CSV list of errors", () => {
+      it("should send cert details (documentStore/DNS-TXT) and errors to Google Analytics", () => {
         const analyticsGenerator = triggerErrorLogging([
           "CERTIFICATE_HASH", // Document has been tampered, naughty naughty!
           "UNISSUED_CERTIFICATE", // Document isn't issued by the given store

--- a/src/sagas/certificate.test.ts
+++ b/src/sagas/certificate.test.ts
@@ -1,7 +1,4 @@
-import {
-  OpenAttestationDocument,
-  IdentityProofType,
-} from "@govtechsg/open-attestation/dist/types/__generated__/schemaV2";
+import { v2 } from "@govtechsg/open-attestation";
 import { call, put, select } from "redux-saga/effects";
 import { getCertificate } from "../reducers/certificate.selectors";
 import { sendCertificate, getCertificateDetails, triggerErrorLogging } from "./certificate";
@@ -132,7 +129,7 @@ describe("sagas/certificate", () => {
         const callGetCertificateDetails = analyticsGenerator.next();
         expect(callGetCertificateDetails.value).toStrictEqual(call(getCertificateDetails));
 
-        const certificate: OpenAttestationDocument = {
+        const certificate: v2.OpenAttestationDocument = {
           id: "MyAwesomeCertID",
           issuers: [
             {
@@ -173,14 +170,14 @@ describe("sagas/certificate", () => {
         const callGetCertificateDetails = analyticsGenerator.next();
         expect(callGetCertificateDetails.value).toStrictEqual(call(getCertificateDetails));
 
-        const certificate: OpenAttestationDocument = {
+        const certificate: v2.OpenAttestationDocument = {
           id: "MyAwesomeCertID",
           issuers: [
             {
               name: "My Awesome Document Store",
               documentStore: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
               identityProof: {
-                type: IdentityProofType.DNSTxt,
+                type: v2.IdentityProofType.DNSTxt,
                 location: "example.openattestation.com",
               },
             },

--- a/src/sagas/certificate.test.ts
+++ b/src/sagas/certificate.test.ts
@@ -1,7 +1,6 @@
-import { v2 } from "@govtechsg/open-attestation";
-import { call, put, select } from "redux-saga/effects";
+import { put, select } from "redux-saga/effects";
 import { getCertificate } from "../reducers/certificate.selectors";
-import { sendCertificate, getCertificateDetails, triggerErrorLogging } from "./certificate";
+import { sendCertificate } from "./certificate";
 import { MakeCertUtil } from "./testutils";
 
 jest.mock("@govtechsg/open-attestation", () => {
@@ -99,112 +98,6 @@ describe("sagas/certificate", () => {
         })
       );
       expect(saga.next().done).toBe(true);
-    });
-  });
-
-  describe("analytics*", () => {
-    // eslint-disable-next-line jest/no-hooks
-    beforeEach(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      // eslint-disable-next-line jest/prefer-spy-on
-      window.ga = jest.fn();
-    });
-    // eslint-disable-next-line jest/no-hooks
-    afterEach(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      // eslint-disable-next-line jest/prefer-spy-on
-      window.ga = undefined;
-    });
-
-    describe("triggerErrorLogging", () => {
-      it("should send cert details (certificateStore) and errors to Google Analytics", () => {
-        const analyticsGenerator = triggerErrorLogging([
-          "CERTIFICATE_HASH", // Document has been tampered, naughty naughty!
-          "UNISSUED_CERTIFICATE", // Document isn't issued by the given store
-          "REVOKED_CERTIFICATE", // Document has been revoked by the given store
-        ]);
-
-        const callGetCertificateDetails = analyticsGenerator.next();
-        expect(callGetCertificateDetails.value).toStrictEqual(call(getCertificateDetails));
-
-        const certificate: v2.OpenAttestationDocument = {
-          id: "MyAwesomeCertID",
-          issuers: [
-            {
-              name: "SEAB",
-              certificateStore: "0xE4a94Ef9C26904A02Cd6735F7D4De1D840146a0f",
-            },
-          ],
-        };
-        analyticsGenerator.next(certificate);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        expect(window.ga).toHaveBeenCalledWith(
-          "send",
-          "event",
-          "CERTIFICATE_ERROR",
-          "ERROR - Singapore Examinations and Assessment Board",
-          "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
-          undefined,
-          {
-            dimension1: "0xE4a94Ef9C26904A02Cd6735F7D4De1D840146a0f",
-            dimension2: "MyAwesomeCertID",
-            dimension3: "(not set)",
-            dimension4: "(not set)",
-            dimension5: "Singapore Examinations and Assessment Board",
-            dimension6: "seab-registry",
-            dimension7: "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
-            nonInteraction: true,
-          }
-        );
-      });
-      it("should send cert details (documentStore/DNS-TXT) and errors to Google Analytics", () => {
-        const analyticsGenerator = triggerErrorLogging([
-          "CERTIFICATE_HASH", // Document has been tampered, naughty naughty!
-          "UNISSUED_CERTIFICATE", // Document isn't issued by the given store
-          "REVOKED_CERTIFICATE", // Document has been revoked by the given store
-        ]);
-
-        const callGetCertificateDetails = analyticsGenerator.next();
-        expect(callGetCertificateDetails.value).toStrictEqual(call(getCertificateDetails));
-
-        const certificate: v2.OpenAttestationDocument = {
-          id: "MyAwesomeCertID",
-          issuers: [
-            {
-              name: "My Awesome Document Store",
-              documentStore: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
-              identityProof: {
-                type: v2.IdentityProofType.DNSTxt,
-                location: "example.openattestation.com",
-              },
-            },
-          ],
-        };
-        analyticsGenerator.next(certificate);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        expect(window.ga).toHaveBeenCalledWith(
-          "send",
-          "event",
-          "CERTIFICATE_ERROR",
-          "ERROR - example.openattestation.com",
-          "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
-          undefined,
-          {
-            dimension1: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
-            dimension2: "MyAwesomeCertID",
-            dimension3: "(not set)",
-            dimension4: "(not set)",
-            dimension5: "example.openattestation.com",
-            dimension6: "(not set)",
-            dimension7: "CERTIFICATE_HASH,UNISSUED_CERTIFICATE,REVOKED_CERTIFICATE",
-            nonInteraction: true,
-          }
-        );
-      });
     });
   });
 });

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -5,7 +5,6 @@ import { get } from "lodash";
 import Router from "next/router";
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import "isomorphic-fetch";
-import registry from "../../public/static/registry.json";
 import { analyticsEvent } from "../components/Analytics";
 import { NETWORK_NAME } from "../config";
 

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -100,7 +100,7 @@ export function* triggerAnalyticsErrorV2(value: string) {
         dimension3: name || "(not set)",
         dimension4: issuedOn || "(not set)",
         dimension5: issuerName || "(not set)",
-        // dimension6: registryIssuer?.id || "(not set)",
+        dimension6: "(not set)", // dimension6: registryIssuer?.id || "(not set)",
         dimension7: errors,
       },
     });

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -64,7 +64,7 @@ export function* verifyCertificate({ payload: certificate }: { payload: WrappedD
       if (!isValid(fragments, ["ISSUER_IDENTITY"])) {
         errors.push("ISSUER_IDENTITY");
       }
-      console.log(certificate);
+
       if (errors.length > 0) {
         triggerErrorLogging(certificate, errors);
       }

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -64,8 +64,8 @@ export function* verifyCertificate({ payload: certificate }: { payload: WrappedD
       if (!isValid(fragments, ["ISSUER_IDENTITY"])) {
         errors.push("ISSUER_IDENTITY");
       }
-
-      if (errors.length) {
+      console.log(certificate);
+      if (errors.length > 0) {
         triggerErrorLogging(certificate, errors);
       }
     }

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -87,7 +87,7 @@ export function* triggerAnalyticsErrorV2(value: string) {
   certificate.issuers.forEach((issuer: v2.Issuer) => {
     const store = issuer.certificateStore ?? issuer.documentStore ?? issuer.tokenRegistry ?? "";
     let issuerName = issuer?.name;
-    const registryIssuer = registry.issuers[store];
+    const registryIssuer = get(registry.issuers, store); // Instead of (a) registry.issuers[store] which causes a type error and (b) using ts-ignore
 
     if (registryIssuer) {
       issuerName = registryIssuer.name;

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -87,8 +87,6 @@ export function* triggerAnalyticsErrorV2(value: string) {
   certificate.issuers.forEach((issuer: v2.Issuer) => {
     const store = issuer.certificateStore ?? issuer.documentStore ?? issuer.tokenRegistry ?? "";
     let issuerName = issuer?.name;
-    // eslint-dis able-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore ignoring because typescript complain the key cant be undefined and there is no match between string type and keyof typeof registry.issuers
     const registryIssuer = registry.issuers[store];
 
     if (registryIssuer) {


### PR DESCRIPTION
In this MR, we draw upon the following ideas to use Google Analytics as an error tracking tool:

- https://www.smashingmagazine.com/2011/10/improve-the-user-experience-by-tracking-errors/
- https://www.analyticsmania.com/post/tracking-errors-with-google-tag-manager/ (can explore in the future)

The idea is to store a stringified list of errors in CSV format, so that it can be processed on our Google Data Studio dashboards using calculated fields.

The following errors are sent:

- `CERTIFICATE_HASH` means the verifier could not match the calculated hash with the `targetHash`, which means the document has been tampered
- `UNISSUED_CERTIFICATE` means the store does not have a record of the `merkleRoot` i.e. the document has not been issued 
- `CERTIFICATE_STORE_NOT_FOUND` means the verifier could not find the store
- `REVOKED_CERTIFICATE` means the `targetHash` or the `merkleRoot` has been revoked by the store
- `ISSUER_IDENTITY` means that the document store address was not found in the DNS TXT records

To test:

- https://deploy-preview-540--opencerts-development.netlify.app/
