### PR TITLE
feat: obtain key from anchor

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import {
 
 interface HomePageProps {
   resetCertificateState: () => void;
-  retrieveCertificateByAction: (payload: { uri: string; key?: string }) => void;
+  retrieveCertificateByAction: (payload: { uri: string; key?: string }, anchor: { key?: string }) => void;
   retrieveCertificateByActionFailure: (message: string) => void;
 }
 const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
@@ -22,8 +22,10 @@ const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
     props.resetCertificateState();
     if (router.query.q) {
       const action = JSON.parse(window.decodeURI(router.query.q as string));
+      const anchorStr = decodeURIComponent(window.location.hash.substr(1));
+      const anchor = anchorStr ? JSON.parse(anchorStr) : {};
       if (action.type === "DOCUMENT") {
-        props.retrieveCertificateByAction(action.payload);
+        props.retrieveCertificateByAction(action.payload, anchor);
       } else {
         props.retrieveCertificateByActionFailure(`The type ${action.type} provided from the action is not supported`);
       }

--- a/src/components/tests/load-action-encrypted-certificate.spec.js
+++ b/src/components/tests/load-action-encrypted-certificate.spec.js
@@ -17,6 +17,36 @@ const validateTextContent = async (t, component, texts) =>
 
 const key = "d1093e704689bcb3a1287daef7644751498b4cbf008d32373a567fe3a112a26e";
 
+test("Load document from action should work when action is valid (key from anchor)", async (t) => {
+  const anchor = { key };
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://gist.githubusercontent.com/Nebulis/328b757c7b56aa5a7d537c88cd250f92/raw/2816aad4811846ee8cd554bd19e08706da19ae09/e2e.json`,
+      permittedAction: ["STORE"],
+      redirect: "https://opencerts.io/",
+    },
+  };
+
+  await t.navigateTo(
+    `http://localhost:3000/?q=${encodeURI(JSON.stringify(action))}#${encodeURI(JSON.stringify(anchor))}`
+  );
+  await validateTextContent(t, StatusButton, ["ROPSTEN: GOVERNMENT TECHNOLOGY AGENCY OF SINGAPORE (GOVTECH)"]);
+
+  await validateTextContent(t, CertificateStatusBanner, [
+    "Certificate issuer is in the SkillsFuture Singapore registry for Opencerts",
+  ]);
+
+  await t.switchToIframe(IframeBlock);
+
+  await validateTextContent(t, SampleTemplate, [
+    "OpenCerts Demo",
+    "Your Name",
+    "has successfully completed the",
+    "John Demo",
+  ]);
+});
+
 test("Load document from action should work when action is valid", async (t) => {
   const action = {
     type: "DOCUMENT",
@@ -61,6 +91,27 @@ test("Load document from action should fail when action type is invalid", async 
     "The certificate can't be loaded",
     "Unable to load certificate with the provided parameters",
     "The type DOCUM provided from the action is not supported",
+  ]);
+});
+
+test("Load document from action should fail when key is invalid (key from anchor)", async (t) => {
+  const anchor = { key: "2a237b35cb50544a2c9a4b4a629e7c547bd1ff4a0137489700891532001e83f6" }; // random key, must have correct length
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://gist.githubusercontent.com/Nebulis/328b757c7b56aa5a7d537c88cd250f92/raw/2816aad4811846ee8cd554bd19e08706da19ae09/e2e.json`,
+      permittedAction: ["STORE"],
+      redirect: "https://opencerts.io/",
+    },
+  };
+
+  await t.navigateTo(
+    `http://localhost:3000/?q=${encodeURI(JSON.stringify(action))}#${encodeURI(JSON.stringify(anchor))}`
+  );
+  await validateTextContent(t, CertificateDropzone, [
+    "The certificate can't be loaded",
+    "Unable to load certificate with the provided parameters",
+    "Error decrypting message",
   ]);
 });
 

--- a/src/reducers/certificate.actions.ts
+++ b/src/reducers/certificate.actions.ts
@@ -147,11 +147,16 @@ export function generateShareLinkFailure(payload: string): GenerateShareLinkFail
 interface RetrieveCertificateAction {
   type: typeof RETRIEVE_CERTIFICATE_BY_ACTION;
   payload: { uri: string; key?: string };
+  anchor: { key?: string };
 }
-export function retrieveCertificateByAction(payload: { uri: string; key?: string }): RetrieveCertificateAction {
+export function retrieveCertificateByAction(
+  payload: { uri: string; key?: string },
+  anchor: { key?: string }
+): RetrieveCertificateAction {
   return {
     type: RETRIEVE_CERTIFICATE_BY_ACTION,
     payload,
+    anchor,
   };
 }
 interface RetrieveCertificatePendingAction {

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -142,7 +142,13 @@ export function* generateShareLink() {
   }
 }
 
-export function* retrieveCertificateByAction({ payload: { uri, key } }: { payload: { uri: string; key?: string } }) {
+export function* retrieveCertificateByAction({
+  payload: { uri, key: payloadKey },
+  anchor: { key: anchorKey },
+}: {
+  payload: { uri: string; key?: string };
+  anchor: { key?: string };
+}) {
   try {
     yield put(retrieveCertificateByActionPending());
 
@@ -160,6 +166,7 @@ export function* retrieveCertificateByAction({ payload: { uri, key } }: { payloa
       throw new Error(`Certificate at address ${uri} is empty`);
     }
     // if there is a key and the type is "OPEN-ATTESTATION-TYPE-1", let's use oa-encryption
+    const key = anchorKey || payloadKey;
     if (key && certificate.type === "OPEN-ATTESTATION-TYPE-1") {
       certificate = JSON.parse(
         decryptString({


### PR DESCRIPTION
In order to keep secrets on the client side, this PR adds the ability to obtain the `key` from the anchor in URLs.

The verifier will now attempt to extract the `key` in the following order:
1. Anchor: `Anchor.key`
2. Query params: `Action.payload.key`

For future extensibility, `Anchor` is an object that will be safely encoded and appended as a string in the URL:
```javascript
{
  key?: string;
}
```
```text
# Decoded example
https://www.opencerts.io/verify?q={"query":"params"}#{"key":"secret"}

# Encoded example
https://www.opencerts.io/verify?q=%7B%22query%22%3A%22params%22%7D%23%7B%22key%22%3A%22secret%22%7D
```