### PR TITLE
fix: smu scis full name

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -160,7 +160,7 @@
       "group": "smu-registry"
     },
     "0x94cbba4b50d2c29d247221a7cc2dda356054078b": {
-      "name": "Singapore Management University School of Information Systems",
+      "name": "Singapore Management University School of Computing and Information Systems",
       "displayCard": true,
       "website": "https://scis.smu.edu.sg",
       "email": "enquiries@scis.smu.edu.sg",


### PR DESCRIPTION
Full name of SCIS should be: "Singapore Management University School of **Computing and** Information Systems"