### PR TITLE
fix: circle ci context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
+version: 2.1
+
 workflows:
-  version: 2
+  build-workflow:
+    jobs:
+      - build:
+          context:
+            - NPM Deployment
 #  uncomment to get build registry
 #  nightly:
 #    triggers:


### PR DESCRIPTION
This pr is to update the npm token that is no longer shared between teams.
