### PR TITLE
chore: show trusted issuer name alongside issuer domain

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,7 @@ module.exports = withBundleAnalyzer({
   env: {
     INFURA_API_KEY: process.env.INFURA_API_KEY || "01b3ed28c54f4ae49cb4e27df560c5e8", // nebulis personal api key, feel free to change
     ALCHEMY_API_KEY: process.env.ALCHEMY_API_KEY || "FK1x9CdE8NStKjVt236D_LP7B6MMCFOs", // default key works on ropsten
+    TRUSTED_TLDS: process.env.TRUSTED_TLDS || "gov.sg,edu.sg",
   },
   // Variables passed to both server and client
   publicRuntimeConfig: {

--- a/src/components/CertificateVerifyBlock/CertificateVerifyBlock.test.tsx
+++ b/src/components/CertificateVerifyBlock/CertificateVerifyBlock.test.tsx
@@ -254,11 +254,13 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
   describe("when issuer domain is trusted", () => {
     let originalEnv: NodeJS.ProcessEnv;
 
+    // eslint-disable-next-line jest/no-hooks
     beforeAll(() => {
       originalEnv = process.env;
       process.env.TRUSTED_TLDS = "gov.sg,trusted-domain.com";
     });
 
+    // eslint-disable-next-line jest/no-hooks
     afterAll(() => {
       process.env = originalEnv;
     });

--- a/src/components/CertificateVerifyBlock/CertificateVerifyBlock.test.tsx
+++ b/src/components/CertificateVerifyBlock/CertificateVerifyBlock.test.tsx
@@ -121,9 +121,14 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
         buildOpencertsRegistryVerifierValidFragment({ name: "Govtech" }),
         buildDnsTxtValidFragment({ location: "abc.com" }),
       ];
-      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }]))).toStrictEqual(
-        "GOVTECH"
-      );
+      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }])))
+        .toMatchInlineSnapshot(`
+        <ol>
+          <li>
+            GOVTECH
+          </li>
+        </ol>
+      `);
     });
 
     it("should return appropriate display text when registry is verified but dns is unverified", () => {
@@ -131,9 +136,14 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
         buildOpencertsRegistryVerifierValidFragment({ name: "Demo" }),
         buildDnsTxtInvalidFragment({ location: "abc.com" }),
       ];
-      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }]))).toStrictEqual(
-        "DEMO"
-      );
+      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }])))
+        .toMatchInlineSnapshot(`
+        <ol>
+          <li>
+            DEMO
+          </li>
+        </ol>
+      `);
     });
 
     it("should return appropriate display identity from registry sort identities", () => {
@@ -143,7 +153,18 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
       ];
       expect(
         getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }, { name: "Issuer 2" }]))
-      ).toStrictEqual("DEMO, GOVTECH");
+      ).toMatchInlineSnapshot(`
+        <ol>
+          <li
+            className="my-2"
+          >
+            DEMO
+          </li>
+          <li>
+            GOVTECH
+          </li>
+        </ol>
+      `);
     });
 
     it("should return appropriate display identity from registry or dns when available and sort by giving priority to registry", () => {
@@ -163,7 +184,18 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
 
       expect(
         getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }, { name: "Issuer 2" }]))
-      ).toStrictEqual("DEMO, ABC.COM");
+      ).toMatchInlineSnapshot(`
+        <ol>
+          <li
+            className="my-2"
+          >
+            DEMO
+          </li>
+          <li>
+            ABC.COM
+          </li>
+        </ol>
+      `);
     });
 
     it("should return Certificate issued by Unknown when registry and dns don't resolve any value", () => {
@@ -172,9 +204,12 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
         buildDnsTxtInvalidFragment({ location: "abc.com" }),
       ];
 
-      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }]))).toStrictEqual(
-        "Unknown"
-      );
+      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }])))
+        .toMatchInlineSnapshot(`
+        <React.Fragment>
+          Unknown
+        </React.Fragment>
+      `);
     });
 
     it("should return registry identity when dns is skipped", () => {
@@ -205,9 +240,14 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
         },
       ];
 
-      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }]))).toStrictEqual(
-        "ROPSTEN: GOVERNMENT TECHNOLOGY AGENCY OF SINGAPORE (GOVTECH)"
-      );
+      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }])))
+        .toMatchInlineSnapshot(`
+        <ol>
+          <li>
+            ROPSTEN: GOVERNMENT TECHNOLOGY AGENCY OF SINGAPORE (GOVTECH)
+          </li>
+        </ol>
+      `);
     });
   });
 
@@ -217,9 +257,14 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
         buildOpencertsRegistryVerifierInvalidFragment({ name: "Govtech" }),
         buildDnsTxtValidFragment({ location: "abc.com" }),
       ];
-      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }]))).toStrictEqual(
-        "ABC.COM"
-      );
+      expect(getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }])))
+        .toMatchInlineSnapshot(`
+        <ol>
+          <li>
+            ABC.COM
+          </li>
+        </ol>
+      `);
     });
 
     it("should return appropriate display text when multiple dns is verified", () => {
@@ -229,7 +274,18 @@ describe("certificate verify block getV2IdentityVerificationText", () => {
       ];
       expect(
         getV2IdentityVerificationText(fragments, buildDocumentWithIssuers([{ name: "Issuer 1" }, { name: "Issuer 2" }]))
-      ).toStrictEqual("DEMO.COM, XYZ.COM");
+      ).toMatchInlineSnapshot(`
+        <ol>
+          <li
+            className="my-2"
+          >
+            DEMO.COM
+          </li>
+          <li>
+            XYZ.COM
+          </li>
+        </ol>
+      `);
     });
   });
 });

--- a/src/components/CertificateVerifyBlock/CertificateVerifyBlock.tsx
+++ b/src/components/CertificateVerifyBlock/CertificateVerifyBlock.tsx
@@ -14,8 +14,6 @@ import { WrappedOrSignedOpenCertsDocument } from "../../shared";
 import { icons } from "../ViewerPageImages";
 import { DetailedCertificateVerifyBlock } from "./DetailedCertificateVerifyBlock";
 
-const TRUSTED_TLDS = process.env.TRUSTED_TLDS?.split(",");
-
 export const getV2IdentityVerificationText = (
   verificationStatus: VerificationFragment[],
   document: WrappedDocument<v2.OpenAttestationDocument>
@@ -67,6 +65,7 @@ export const getV2IdentityVerificationText = (
 
   if (identities.length > 0) {
     const isTrusted = (location: string): boolean => {
+      const TRUSTED_TLDS = process.env.TRUSTED_TLDS?.split(",");
       return TRUSTED_TLDS ? TRUSTED_TLDS.some((tld) => location.toUpperCase().endsWith(tld.toUpperCase())) : false;
     };
 


### PR DESCRIPTION
**What does this PR do?**
- Allow trusted issuer to have their name shown alongside issuer domain
- Trusted TLDs: `*.gov.sg` and `*.edu.sg`
- Example:
  ```text
  Certificate issued by
  NTU.EDU.SG
  NANYANG TECHNOLOGICAL UNIVERSITY
  ```

| Before | After |
|---|---|
| ![Screenshot 2022-03-07 at 2 54 06 PM](https://user-images.githubusercontent.com/37650399/156982643-ca0e49f6-0907-4d83-9b16-1be4c87e75cc.png) | ![Screenshot 2022-03-07 at 2 54 15 PM](https://user-images.githubusercontent.com/37650399/156982671-e93efe20-f538-4c4d-a5eb-8c6cf6af60ba.png) |