### PR TITLE
chore: add opencerts and tradetrust goerli addr

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -341,6 +341,14 @@
     "0x7Ee2B9a0043Bda975398477695ba5c2361acC50C": {
       "name": "RINKEBY: Government Technology Agency of Singapore (GovTech)",
       "displayCard": false
+    },
+    "0xb3db78c0cc3622e078622C8395095a7B95415Acf": {
+      "name": "GOERLI: Government Technology Agency of Singapore (GovTech)",
+      "displayCard": false
+    },
+    "0x49b2969bF0E4aa822023a9eA2293b24E4518C1DD": {
+      "name": "GOERLI: Government Technology Agency of Singapore (GovTech)",
+      "displayCard": false
     }
   }
 }


### PR DESCRIPTION
**What this PR does:**
- Add 2 new Goerli document store addresses into registry.json