### PR TITLE
fix: use poppins font for headings

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,7 +12,7 @@ export default class MyDocument extends Document {
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
           <link
-            href="https://fonts.googleapis.com/css2?family=Montserrat&family=Poppins&family=Source+Sans+Pro&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Poppins&family=Source+Sans+Pro&display=swap"
             rel="stylesheet"
           />
           <link

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,8 +9,12 @@ export default class MyDocument extends Document {
         <Head>
           <link rel="icon" type="image/png" href="/static/images/favicon/favicon-32x32.png" sizes="32x32" />
           <link rel="icon" type="image/png" href="/static/images/favicon/favicon-16x16.png" sizes="16x16" />
-          <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet" />
-          <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet" type="text/css" />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Montserrat&family=Source+Sans+Pro&display=swap"
+            rel="stylesheet"
+          />
           <link
             rel="stylesheet"
             href="https://use.fontawesome.com/releases/v5.2.0/css/all.css"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,7 +12,7 @@ export default class MyDocument extends Document {
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
           <link
-            href="https://fonts.googleapis.com/css2?family=Montserrat&family=Source+Sans+Pro&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Montserrat&family=Poppins&family=Source+Sans+Pro&display=swap"
             rel="stylesheet"
           />
           <link

--- a/src/components/FAQ/FaqContent.tsx
+++ b/src/components/FAQ/FaqContent.tsx
@@ -4,15 +4,15 @@ import { faqContent } from "./content";
 export const FaqContent: React.FunctionComponent = () => (
   <section className="mb-20 text-sm text-gray-800 links-blue">
     <div className="container">
-      <h1 className="font-montserrat py-12 text-center">Frequently Asked Questions</h1>
+      <h1 className="font-poppins py-12 text-center">Frequently Asked Questions</h1>
 
       {faqContent.map(({ category, faq }, index) => (
         <div className="flex flex-wrap justify-center mb-12" key={index}>
           <div className="w-full lg:w-2/3">
-            <h2 className="text-orange-600 font-montserrat font-bold text-lg">{category}</h2>
+            <h2 className="text-orange-600 font-poppins font-bold text-lg">{category}</h2>
             {faq.map(({ question, answer, ...extraProps }, faqIndex) => (
               <div className="py-4" key={faqIndex} {...extraProps}>
-                <h3 className="font-montserrat font-bold text-gray-700 mb-2 text-md">{question}</h3>
+                <h3 className="font-poppins font-bold text-gray-700 mb-2 text-md">{question}</h3>
                 {answer}
               </div>
             ))}

--- a/src/components/HomePageContent/AboutSection.tsx
+++ b/src/components/HomePageContent/AboutSection.tsx
@@ -21,13 +21,13 @@ export const AboutSection: React.FunctionComponent = () => {
     <>
       <section className="bg-navy text-white py-20">
         <div className="container">
-          <h2 className="font-montserrat mb-12 pl-8 border-l-4 border-orange">What we can help you do</h2>
+          <h2 className="font-poppins mb-12 pl-8 border-l-4 border-orange">What we can help you do</h2>
           <div className="flex flex-wrap">
             <div className="w-full lg:w-1/3 py-6">
               <div className="flex flex-wrap">
                 <div className="w-auto">{aboutImages.valid()}</div>
                 <div className="w-2/3 px-6">
-                  <h3 className="font-montserrat font-bold text-orange mb-2">View</h3>
+                  <h3 className="font-poppins font-bold text-orange mb-2">View</h3>
                   <p>Easy way to view your certificate</p>
                 </div>
               </div>
@@ -36,7 +36,7 @@ export const AboutSection: React.FunctionComponent = () => {
               <div className="flex flex-wrap">
                 <div className="w-auto">{aboutImages.genuine()}</div>
                 <div className="w-2/3 px-6">
-                  <h3 className="font-montserrat font-bold text-orange mb-2">Check</h3>
+                  <h3 className="font-poppins font-bold text-orange mb-2">Check</h3>
                   <p>Make sure it has not been tampered with</p>
                 </div>
               </div>
@@ -45,7 +45,7 @@ export const AboutSection: React.FunctionComponent = () => {
               <div className="flex flex-wrap">
                 <div className="w-auto">{aboutImages.institution()}</div>
                 <div className="w-2/3 px-6">
-                  <h3 className="font-montserrat font-bold text-orange mb-2">Verify</h3>
+                  <h3 className="font-poppins font-bold text-orange mb-2">Verify</h3>
                   <p>Find out if it is from a recognised institution</p>
                 </div>
               </div>
@@ -55,7 +55,7 @@ export const AboutSection: React.FunctionComponent = () => {
       </section>
       <section className="bg-blue-100 py-20">
         <div className="container">
-          <h2 className="font-montserrat mb-12 pl-8 border-l-4 border-orange">How it works</h2>
+          <h2 className="font-poppins mb-12 pl-8 border-l-4 border-orange">How it works</h2>
           <div className="bg-white rounded shadow-md p-8">
             {howitworks.map((item, i) => (
               <div key={i} className="flex flex-wrap items-center justify-center py-8">

--- a/src/components/HomePageContent/DropZoneSection.tsx
+++ b/src/components/HomePageContent/DropZoneSection.tsx
@@ -112,7 +112,7 @@ class DropZoneSection extends Component<DropZoneSectionProps> {
         <div className="container">
           <div className="flex flex-wrap">
             <div className="w-full lg:w-1/3 lg:pr-10 text-center lg:text-left">
-              <h1 className="font-montserrat mb-5">An easy way to check and verify your OpenCerts certificates</h1>
+              <h1 className="font-poppins mb-5">An easy way to check and verify your OpenCerts certificates</h1>
               <p>Whether you are a student or an employer, verify any OpenCerts certificate here.</p>
               <DraggableDemoCertificate />
               <MobileDemoCertificate />

--- a/src/components/Layout/FooterBar.tsx
+++ b/src/components/Layout/FooterBar.tsx
@@ -8,7 +8,7 @@ export const FooterBar: React.FunctionComponent = () => (
     <div className="container pt-8 pb-12">
       <div className="flex flex-wrap">
         <div className="w-40 lg:mr-40 mb-8 lg:mb-0">
-          <p className="font-montserrat font-bold mb-2">Powered by</p>
+          <p className="font-poppins font-bold mb-2">Powered by</p>
           <a
             className="inline-block transition-opacity hover:opacity-75"
             href="https://hive.tech.gov.sg/"
@@ -19,7 +19,7 @@ export const FooterBar: React.FunctionComponent = () => (
           </a>
         </div>
         <div className="w-full lg:w-40 mb-8 lg:mb-0">
-          <p className="font-montserrat font-bold mb-2">Partners</p>
+          <p className="font-poppins font-bold mb-2">Partners</p>
           <ul className="text-sm">
             <li>
               <Link href="/collaborate">
@@ -34,7 +34,7 @@ export const FooterBar: React.FunctionComponent = () => (
           </ul>
         </div>
         <div className="w-full lg:w-40 mb-8 lg:mb-0">
-          <p className="font-montserrat font-bold mb-2">Support</p>
+          <p className="font-poppins font-bold mb-2">Support</p>
           <ul className="text-sm">
             <li>
               <Link href="/faq">
@@ -59,7 +59,7 @@ export const FooterBar: React.FunctionComponent = () => (
           </ul>
         </div>
         <div className="w-full lg:w-40">
-          <p className="font-montserrat font-bold mb-2">Legal</p>
+          <p className="font-poppins font-bold mb-2">Legal</p>
           <ul className="text-sm">
             <li>
               <Link href="/privacy">

--- a/src/components/Layout/NavigationBar/NavigationBar.tsx
+++ b/src/components/Layout/NavigationBar/NavigationBar.tsx
@@ -24,7 +24,7 @@ export const NavigationBar: React.FunctionComponent = () => {
         <div className="flex flex-wrap items-center">
           <div className="w-2/5 sm:w-1/3 md:w-1/4 lg:w-1/6 mr-auto mb-6 md:mb-0">
             <Link href="/">
-              <a className="font-montserrat">
+              <a className="font-poppins">
                 <img src="/static/images/opencertslogo.svg" alt="OpenCerts" />
               </a>
             </Link>
@@ -32,7 +32,7 @@ export const NavigationBar: React.FunctionComponent = () => {
           {navItems.map((n, i) => (
             <div className="w-full md:w-auto md:pl-8 mb-2 md:mb-0" key={i}>
               <Link href={n.path}>
-                <a className={`font-montserrat ${router.pathname === n.path ? "text-white" : ""}`}>{n.label}</a>
+                <a className={`font-poppins ${router.pathname === n.path ? "text-white" : ""}`}>{n.label}</a>
               </Link>
             </div>
           ))}

--- a/src/components/Privacy/PrivacyContent.tsx
+++ b/src/components/Privacy/PrivacyContent.tsx
@@ -4,7 +4,7 @@ export const PrivacyContent: React.FunctionComponent = () => (
   <section className="mb-20 text-sm text-gray-800">
     <div className="container">
       <div className="xl:px-48">
-        <h1 className="font-montserrat py-12 text-center">Privacy Policy</h1>
+        <h1 className="font-poppins py-12 text-center">Privacy Policy</h1>
         <p>
           This Privacy Policy must be read in conjunction with the Terms of Use that accompany the applicable service
           you are requesting from us (the &#34;Service&#34;). In this Privacy Policy, &#34;Public Sector Entities&#34;

--- a/src/components/TermsOfUse/TermsOfUseContent.tsx
+++ b/src/components/TermsOfUse/TermsOfUseContent.tsx
@@ -5,7 +5,7 @@ export const TermsOfUseContent: React.FunctionComponent = () => (
   <section className="mb-20 text-sm text-gray-800 links-blue">
     <div className="container">
       <div className="xl:px-48">
-        <h1 className="font-montserrat py-12 text-center">Terms of Use</h1>
+        <h1 className="font-poppins py-12 text-center">Terms of Use</h1>
         <ol className="list-decimal pl-4">
           <li>
             <b>General</b>
@@ -447,7 +447,7 @@ export const TermsOfUseContent: React.FunctionComponent = () => (
           </li>
         </ol>
         <p>This version of the Terms of Use is dated 20 August 2018.</p>
-        <h1 className="font-montserrat py-12 text-center">Schedule</h1>
+        <h1 className="font-poppins py-12 text-center">Schedule</h1>
         <ol className="list-decimal pl-4">
           <li>
             <p>

--- a/src/components/UI/Card/card.tsx
+++ b/src/components/UI/Card/card.tsx
@@ -19,7 +19,7 @@ export const Card: React.FunctionComponent<CardProps> = (props) => (
       key={props.info[0].id}
       onClick={() => window.open(props.info[0].website)}
     >
-      <h2 className="font-montserrat font-bold text-lg">{props.info[0].name}</h2>
+      <h2 className="font-poppins font-bold text-lg">{props.info[0].name}</h2>
       <img className="h-12 max-w-10 mx-auto m-6" src={props.info[0].logo} alt={props.info[0].name} />
       {props.info.map((info, index) => (
         <div className="links-blue" key={info.id}>

--- a/src/components/UI/Hero/Hero.tsx
+++ b/src/components/UI/Hero/Hero.tsx
@@ -11,10 +11,10 @@ export const Hero: React.FunctionComponent<HeroProps> = ({ heading, subHeading, 
     <div className="container">
       <div className="flex flex-wrap">
         <div className="w-full lg:w-auto lg:mr-20">
-          <h1 className="font-montserrat">{heading}</h1>
+          <h1 className="font-poppins">{heading}</h1>
         </div>
         <div className="w-full" style={{ maxWidth: "410px" }}>
-          {subHeading && <h3 className="font-montserrat mb-6">{subHeading}</h3>}
+          {subHeading && <h3 className="font-poppins mb-6">{subHeading}</h3>}
           <div className="text-sm">{children}</div>
         </div>
       </div>

--- a/src/components/UI/RegistryCard/RegistryCard.tsx
+++ b/src/components/UI/RegistryCard/RegistryCard.tsx
@@ -56,7 +56,7 @@ export const RegistryCard: React.FunctionComponent<RegistryCardProps> = ({ zInde
             />
           </div>
           <div className="flex-1 pt-16 px-4">
-            <h4 className="font-montserrat font-bold" data-testid="institute-name">
+            <h4 className="font-poppins font-bold" data-testid="institute-name">
               {contact[0].name}
             </h4>
           </div>
@@ -82,7 +82,7 @@ export const RegistryCard: React.FunctionComponent<RegistryCardProps> = ({ zInde
                   (info) =>
                     info.address?.includes(search) && (
                       <div key={info.id} className="p-4" data-testid="info">
-                        {info.name && <h5 className="font-bold font-montserrat mb-4">{info.name}</h5>}
+                        {info.name && <h5 className="font-bold font-poppins mb-4">{info.name}</h5>}
                         {info.address && info.website && (
                           <a
                             className="block text-gray-700 hover:text-gray-700 hover:underline"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     fontFamily: {
       "source-sans-pro": ["Source Sans Pro", "sans-serif"],
-      montserrat: ["Poppins", "sans-serif"],
+      poppins: ["Poppins", "sans-serif"],
     },
     fontSize: {
       xs: ["14px", "20px"],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     fontFamily: {
       "source-sans-pro": ["Source Sans Pro", "sans-serif"],
-      montserrat: ["Montserrat", "sans-serif"],
+      montserrat: ["Poppins", "sans-serif"],
     },
     fontSize: {
       xs: ["14px", "20px"],


### PR DESCRIPTION
## Context
SOE was encountering some rendering issues with the `Montserrat` font

![image](https://user-images.githubusercontent.com/37650399/198924984-6f648793-bf17-41c6-9479-daad6280b633.png)

## The fix
- [Doesn't work] ~~Try to import Google Fonts using the recommended way: https://fonts.google.com/share?selection.family=Montserrat%7CSource%20Sans%20Pro~~
- Switch to use Poppins font for headings