### PR TITLE
chore: add seab (goerli) into registry

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -294,6 +294,10 @@
       "name": "ROPSTEN: Singapore Examinations and Assessment Board",
       "displayCard": false
     },
+    "0x1f8A474e7D62Cd64F27B5037bd3541886441981B": {
+      "name": "GOERLI: Singapore Examinations and Assessment Board",
+      "displayCard": false
+    },
     "0x897E224a6a8b72535D67940B3B8CE53f9B596800": {
       "name": "ROPSTEN: Singapore Institute of Technology",
       "displayCard": false


### PR DESCRIPTION
## What does this PR do?

Add Singapore Examinations and Assessment Board (SEAB) Goerli document store address into the registry