### PR TITLE
chore: add smu (goerli) into registry

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -266,6 +266,10 @@
       "name": "ROPSTEN: Singapore Management University",
       "displayCard": false
     },
+    "0x58ae2F4D8A1A32e1BBf3B60B226150eD5cd6d028": {
+      "name": "GOERLI: Singapore Management University",
+      "displayCard": false
+    },
     "0x3FFB6b913E9874c7ddabD564d85676Bc5cAd16d4": {
       "name": "ROPSTEN: Nanyang Technological University",
       "displayCard": false


### PR DESCRIPTION
## What does this PR do?

Add Singapore Management University (SMU) Goerli document store address into the registry