### PR TITLE
chore: add sp (goerli) into registry

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -346,6 +346,10 @@
       "name": "GOERLI: Republic Polytechnic",
       "displayCard": false
     },
+    "0x8b1ee9507681fea227d78ef9377d0f054856b774": {
+      "name": "GOERLI: Singapore Polytechnic",
+      "displayCard": false
+    },
     "0x2456FC81C1342fB79D7C58A4682F031208A44d7F": {
       "name": "ROPSTEN: Singapore University of Technology and Design",
       "displayCard": false


### PR DESCRIPTION
## What does this PR do?

Add Singapore Polytechnic (SP) Goerli document store address into the registry