### PR TITLE
chore: add Goerli address for Nanyang Polytechnic

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -278,6 +278,10 @@
       "name": "ROPSTEN: Nanyang Polytechnic",
       "displayCard": false
     },
+    "0xDcb5bCe006f5F369579854EC32eC6fa53ba915Be": {
+      "name": "GOERLI: Nanyang Polytechnic",
+      "displayCard": false
+    },
     "0xfEbB273495F5C2c4783E23424Fe9773691b57fcB": {
       "name": "ROPSTEN: National University of Singapore",
       "displayCard": false


### PR DESCRIPTION
## What this PR does
- Add new Goerli document store address into the registry for Nanyang Polytechnic 
