### PR TITLE
chore: remove NYP Ropsten document store address

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -274,10 +274,6 @@
       "name": "ROPSTEN: Nanyang Technological University",
       "displayCard": false
     },
-    "0xdcb5bce006f5f369579854ec32ec6fa53ba915be": {
-      "name": "ROPSTEN: Nanyang Polytechnic",
-      "displayCard": false
-    },
     "0xDcb5bCe006f5F369579854EC32eC6fa53ba915Be": {
       "name": "GOERLI: Nanyang Polytechnic",
       "displayCard": false


### PR DESCRIPTION
## What this PR does
- Removed duplicated key ID of NYP's deprecated Ropsten document store to prevent fetching wrong data from registry