### PR TITLE
feat: add Sepolia address

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -381,6 +381,10 @@
     "0x80732bF5CA47A85e599f3ac9572F602c249C8A28": {
       "name": "MUMBAI: Government Technology Agency of Singapore (GovTech)",
       "displayCard": false
+    },
+    "0x80ca96D2Aab5E1E23876a4D8140Ee1292327a4cd": {
+      "name": "SEPOLIA: Government Technology Agency of Singapore (GovTech)",
+      "displayCard": false
     }
   }
 }


### PR DESCRIPTION
## Context
- To add in the Sepolia address so that `opencerts-function` and related repos' test files will show that the address is a valid `OpencertsRegistryVerifier` 
- Snippet of how a part of the result of the OpenCerts verification should look like after the change:
```
 {
              type: "ISSUER_IDENTITY",
              name: "OpencertsRegistryVerifier",
              status: "VALID",
              data: [
                {
                  status: "VALID",
                  value: "0x80ca96D2Aab5E1E23876a4D8140Ee1292327a4cd",
                  name: "SEPOLIA: Government Technology Agency of Singapore (GovTech)",
                  displayCard: false
                }
              ]
            }
...
```

## What this PR does
- Add in Sepolia address `0x80ca96D2Aab5E1E23876a4D8140Ee1292327a4cd` into `registry.json` 