### PR TITLE
fix: check revocation status of did signed documents

### DIFF
--- a/src/services/fragment.ts
+++ b/src/services/fragment.ts
@@ -45,7 +45,7 @@ export const certificateRevoked = (fragments: VerificationFragment[]): boolean =
   const documentStoreIssuedFragment = utils.getOpenAttestationEthereumDocumentStoreStatusFragment(fragments);
   // 1 is the error code used by oa-verify in case of document / token not issued / minted
   return (
-    didSignedFragment?.data.revokedOnAny === true ||
+    didSignedFragment?.data?.revokedOnAny === true ||
     documentStoreIssuedFragment?.reason?.code === OpenAttestationEthereumDocumentStoreStatusCode.DOCUMENT_REVOKED
   );
 };

--- a/src/services/fragment.ts
+++ b/src/services/fragment.ts
@@ -1,5 +1,4 @@
 import {
-  OpenAttestationDidSignedDocumentStatusVerificationFragment,
   OpenAttestationEthereumDocumentStoreStatusCode,
   OpenAttestationEthereumTokenRegistryStatusCode,
   VerificationFragment,

--- a/src/services/fragment.ts
+++ b/src/services/fragment.ts
@@ -1,4 +1,5 @@
 import {
+  OpenAttestationDidSignedDocumentStatusVerificationFragment,
   OpenAttestationEthereumDocumentStoreStatusCode,
   OpenAttestationEthereumTokenRegistryStatusCode,
   VerificationFragment,
@@ -41,9 +42,13 @@ export const certificateNotIssued = (fragments: VerificationFragment[]): boolean
 
 // this function check if the reason of the error is that the document store or token has not been issued
 export const certificateRevoked = (fragments: VerificationFragment[]): boolean => {
+  const didSignedFragment = utils.getOpenAttestationDidSignedDocumentStatusFragment(fragments);
   const documentStoreIssuedFragment = utils.getOpenAttestationEthereumDocumentStoreStatusFragment(fragments);
   // 1 is the error code used by oa-verify in case of document / token not issued / minted
-  return documentStoreIssuedFragment?.reason?.code === OpenAttestationEthereumDocumentStoreStatusCode.DOCUMENT_REVOKED;
+  return (
+    didSignedFragment?.data.revokedOnAny === true ||
+    documentStoreIssuedFragment?.reason?.code === OpenAttestationEthereumDocumentStoreStatusCode.DOCUMENT_REVOKED
+  );
 };
 
 // this function check if the error is caused by an invalid merkle root (incorrect length/odd length/invalid characters)


### PR DESCRIPTION
## Context
For DID-signed certificates that utilises an OCSP Responder, the verifier throws a generic error message (`Whoops! It's not you, it's us`) instead of a revoked message (`Certificate has been revoked`)

## What does this PR do?
- Update `certificateRevoked()` checks to also include fragments from DID-signed documents
- Check against `revokedOnAny === true` for a catch all solution
  - For a stricter check, can refer to [Verify's implementation](https://github.com/Open-Attestation/verify.gov.sg/blob/e2b520dedb7dc2bb2e648a112827017b5a3fdea8/components/verify/Verifier.tsx#L78-L81)
  - tl;dr Not straight forward to check `reason.code` as OCSP Revocation uses [reason codes as the revocation reason](https://github.com/Open-Attestation/ocsp-responder#reasoncode) (not to be confused with [OA status code](https://github.com/Open-Attestation/oa-verify/blob/5bf986c476cc32a2199bf12f8ba713a2624db9ab/src/types/error.ts#L11))
- Fixes #735