### PR TITLE
chore: add TradeTrust Sepolia addr into registry

### DIFF
--- a/public/static/registry.json
+++ b/public/static/registry.json
@@ -386,6 +386,10 @@
       "name": "MUMBAI: Government Technology Agency of Singapore (GovTech)",
       "displayCard": false
     },
+    "0x71D28767662cB233F887aD2Bb65d048d760bA694": {
+      "name": "SEPOLIA: Government Technology Agency of Singapore (GovTech)",
+      "displayCard": false
+    },
     "0x80ca96D2Aab5E1E23876a4D8140Ee1292327a4cd": {
       "name": "SEPOLIA: Government Technology Agency of Singapore (GovTech)",
       "displayCard": false


### PR DESCRIPTION
## What this PR does
- Adds TradeTrust Sepolia document store address which is used in some tests