### PR TITLE
fix: remove width restriction on icon

### DIFF
--- a/src/components/UI/Card/card.tsx
+++ b/src/components/UI/Card/card.tsx
@@ -20,7 +20,7 @@ export const Card: React.FunctionComponent<CardProps> = (props) => (
       onClick={() => window.open(props.info[0].website)}
     >
       <h2 className="font-poppins font-bold text-lg">{props.info[0].name}</h2>
-      <img className="h-12 max-w-10 mx-auto m-6" src={props.info[0].logo} alt={props.info[0].name} />
+      <img className="h-12 mx-auto m-6" src={props.info[0].logo} alt={props.info[0].name} />
       {props.info.map((info, index) => (
         <div className="links-blue" key={info.id}>
           {info.address && (


### PR DESCRIPTION
## Context
- Icons in collaborate page are being constricted

## What this PR does
- Remove width restriction on icons in the collaborate page