### PR TITLE
fix: use dedicated WOGAA_ENV env var instead

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,7 @@ module.exports = withBundleAnalyzer({
     ALCHEMY_API_KEY: process.env.ALCHEMY_API_KEY || "FK1x9CdE8NStKjVt236D_LP7B6MMCFOs", // default key works on ropsten
     TRUSTED_TLDS: process.env.TRUSTED_TLDS || "gov.sg,edu.sg",
     GA4_TAG_ID: process.env.GA4_TAG_ID || "G-JP12T2F01V",
+    WOGAA_ENV: process.env.WOGAA_ENV || "production",
   },
   // Variables passed to both server and client
   publicRuntimeConfig: {

--- a/src/components/Analytics/wogaa.tsx
+++ b/src/components/Analytics/wogaa.tsx
@@ -35,11 +35,7 @@ export const completeTransactionalService: typeof window.wogaaCustom.completeTra
 export const Wogaa = () => (
   <script
     src={
-      // NODE_ENV is automatically set by Next.js: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#good-to-know
-      // The allowed values for NODE_ENV: "production", "development" or "test"
-      // e.g. npm run dev -> NODE_ENV === "development"
-      // e.g. npm run build -> NODE_ENV === "production"
-      process.env.NODE_ENV === "production"
+      process.env.WOGAA_ENV === "production"
         ? "https://assets.wogaa.sg/scripts/wogaa.js"
         : "https://assets.dcube.cloud/scripts/wogaa.js"
     }


### PR DESCRIPTION
`process.env.NODE_ENV` cannot be overwritten
