### PR TITLE
fix: scrub url before loading woogaa

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,5 @@
 import { Head, Html, Main, NextScript } from "next/document";
 import React from "react";
-import { Wogaa } from "../src/components/Analytics/wogaa";
 
 export default function Document() {
   return (
@@ -21,7 +20,6 @@ export default function Document() {
           crossOrigin="anonymous"
         />
         <link rel="stylesheet" href="/static/style.css" />
-        <Wogaa />
       </Head>
       <body>
         <Main />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,7 +33,7 @@ const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
   }, [props, router]);
 
   return (
-    <Wrapper>
+    <Wrapper isScrubUrlBeforeLoadingWogaa>
       <NavigationBar />
       <Main>
         <MainPageContainer />

--- a/src/components/Analytics/wogaa.tsx
+++ b/src/components/Analytics/wogaa.tsx
@@ -1,3 +1,4 @@
+import Script from "next/script";
 import React from "react";
 import { WOGAA_TRANSACTIONAL_SERVICE } from "../../config";
 
@@ -33,7 +34,7 @@ export const completeTransactionalService: typeof window.wogaaCustom.completeTra
 };
 
 export const Wogaa = () => (
-  <script
+  <Script
     src={
       process.env.WOGAA_ENV === "production"
         ? "https://assets.wogaa.sg/scripts/wogaa.js"

--- a/src/components/Layout/Body.tsx
+++ b/src/components/Layout/Body.tsx
@@ -1,12 +1,73 @@
+import { ParsedUrlQuery } from "querystring";
+
+import { useRouter } from "next/router";
 import React from "react";
+import { useEffect, useState } from "react";
+import { Wogaa } from "../Analytics/wogaa";
+
+type UseUrlParamsThenScrubUrlParam = {
+  /** extraction and scrubbing will only happen if this is true */
+  enabled: boolean;
+};
+type UrlParams = {
+  uriFragment: string;
+  query: ParsedUrlQuery;
+};
+const useUrlParamsThenScrubUrl = ({ enabled }: UseUrlParamsThenScrubUrlParam): UrlParams | undefined => {
+  // urlParams will only be undefined before the second render
+  // being undefined means the urlParams has not been extracted and the url has not been scrubbed yet
+  const [urlParams, setUrlParams] = useState<UrlParams | undefined>(
+    !enabled
+      ? {
+          uriFragment: "",
+          query: {},
+        }
+      : undefined
+  );
+  const router = useRouter();
+
+  useEffect(() => {
+    if (enabled) {
+      setUrlParams((currUrlParams) => {
+        // once the fragment is set, we never update it again
+        if (currUrlParams !== undefined) {
+          return currUrlParams;
+        }
+
+        const savedFragment = window.location.hash.substring(1);
+        const savedQueryParam = { ...router.query };
+
+        // scrubbbb itttttt
+        window.location.hash = "";
+        router.replace({}, undefined, { shallow: true });
+        return {
+          uriFragment: savedFragment,
+          query: savedQueryParam,
+        };
+      });
+    }
+  }, [urlParams, router, enabled]);
+
+  return urlParams;
+};
 
 interface WrapperProps {
   children: React.ReactNode;
+  isScrubUrlBeforeLoadingWogaa?: boolean;
 }
 
-export const Wrapper: React.FunctionComponent<WrapperProps> = ({ children }) => (
-  <div className="flex flex-col h-screen wrapper">{children}</div>
-);
+export const Wrapper: React.FunctionComponent<WrapperProps> = ({ children, isScrubUrlBeforeLoadingWogaa = false }) => {
+  // urlParams being defined means the url has been extracted and scrubbed
+  const urlParams = useUrlParamsThenScrubUrl({ enabled: isScrubUrlBeforeLoadingWogaa });
+
+  return (
+    <>
+      {!isScrubUrlBeforeLoadingWogaa && <Wogaa />}
+      {isScrubUrlBeforeLoadingWogaa && urlParams ? <Wogaa /> : null}
+      <div className="flex flex-col h-screen wrapper">{children}</div>
+    </>
+  );
+};
 
 interface MainProps {
   children: React.ReactNode;

--- a/src/components/Layout/Body.tsx
+++ b/src/components/Layout/Body.tsx
@@ -59,7 +59,6 @@ interface WrapperProps {
 export const Wrapper: React.FunctionComponent<WrapperProps> = ({ children, isScrubUrlBeforeLoadingWogaa = false }) => {
   // urlParams being defined means the url has been extracted and scrubbed
   const urlParams = useUrlParamsThenScrubUrl({ enabled: isScrubUrlBeforeLoadingWogaa });
-
   return (
     <>
       {!isScrubUrlBeforeLoadingWogaa && <Wogaa />}


### PR DESCRIPTION
## Why
URL params and fragments may contain sensitive data that should not be sent to wooga

## What
1. Remove including of woooga script tag in all page server side renders
2. Loading of script done on client side
3. Scrub url on verify (main page) before loading wogaa
4. Allow wogaa transactions to be buffered before the script is loaded