### PR TITLE
fix: did not use scrubbed query params

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,6 +25,8 @@ const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
   useEffect(() => {
     if (urlParams === undefined) return;
 
+    console.log(urlParams);
+
     props.resetCertificateState();
     if (urlParams.query.q) {
       const action = JSON.parse(window.decodeURI(urlParams.query.q as string));
@@ -86,7 +88,9 @@ const useUrlParamsThenScrubUrl = ({ enabled }: UseUrlParamsThenScrubUrlParam): U
         }
 
         const savedFragment = window.location.hash.substring(1);
-        const savedQueryParam = { ...router.query };
+        // router.query does not work when next is built in static mode
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const savedQueryParam = Object.fromEntries(urlSearchParams.entries());
 
         // scrubbbb itttttt
         window.location.hash = "";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,13 @@
+import { ParsedUrlQuery } from "querystring";
 import { useRouter } from "next/router";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
+import { Wogaa } from "../src/components/Analytics/wogaa";
 import { Wrapper, Main } from "../src/components/Layout/Body";
 import { FooterBar } from "../src/components/Layout/FooterBar";
 import { NavigationBar } from "../src/components/Layout/NavigationBar";
 import { MainPageContainer } from "../src/components/MainPageContainer";
+
 import {
   resetCertificateState,
   retrieveCertificateByActionFailure,
@@ -17,12 +20,15 @@ interface HomePageProps {
   retrieveCertificateByActionFailure: (message: string) => void;
 }
 const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
-  const router = useRouter();
+  const urlParams = useUrlParamsThenScrubUrl({ enabled: true });
+
   useEffect(() => {
+    if (urlParams === undefined) return;
+
     props.resetCertificateState();
-    if (router.query.q) {
-      const action = JSON.parse(window.decodeURI(router.query.q as string));
-      const anchorStr = decodeURIComponent(window.location.hash.substr(1));
+    if (urlParams.query.q) {
+      const action = JSON.parse(window.decodeURI(urlParams.query.q as string));
+      const anchorStr = decodeURIComponent(urlParams.uriFragment);
       const anchor = anchorStr ? JSON.parse(anchorStr) : {};
       if (action.type === "DOCUMENT") {
         props.retrieveCertificateByAction(action.payload, anchor);
@@ -30,10 +36,11 @@ const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
         props.retrieveCertificateByActionFailure(`The type ${action.type} provided from the action is not supported`);
       }
     }
-  }, [props, router]);
+  }, [props, urlParams]);
 
   return (
-    <Wrapper isScrubUrlBeforeLoadingWogaa>
+    <Wrapper isLoadWogaa={false}>
+      {urlParams ? <Wogaa /> : null}
       <NavigationBar />
       <Main>
         <MainPageContainer />
@@ -48,3 +55,49 @@ export default connect(null, {
   retrieveCertificateByAction,
   retrieveCertificateByActionFailure,
 })(HomePage);
+
+type UseUrlParamsThenScrubUrlParam = {
+  /** extraction and scrubbing will only happen if this is true */
+  enabled: boolean;
+};
+type UrlParams = {
+  uriFragment: string;
+  query: ParsedUrlQuery;
+};
+const useUrlParamsThenScrubUrl = ({ enabled }: UseUrlParamsThenScrubUrlParam): UrlParams | undefined => {
+  // urlParams will only be undefined before the second render
+  // being undefined means the urlParams has not been extracted and the url has not been scrubbed yet
+  const [urlParams, setUrlParams] = useState<UrlParams | undefined>(
+    !enabled
+      ? {
+          uriFragment: "",
+          query: {},
+        }
+      : undefined
+  );
+  const router = useRouter();
+
+  useEffect(() => {
+    if (enabled) {
+      setUrlParams((currUrlParams) => {
+        // once the fragment is set, we never update it again
+        if (currUrlParams !== undefined) {
+          return currUrlParams;
+        }
+
+        const savedFragment = window.location.hash.substring(1);
+        const savedQueryParam = { ...router.query };
+
+        // scrubbbb itttttt
+        window.location.hash = "";
+        router.replace({}, undefined, { shallow: true });
+        return {
+          uriFragment: savedFragment,
+          query: savedQueryParam,
+        };
+      });
+    }
+  }, [urlParams, router, enabled]);
+
+  return urlParams;
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,8 +25,6 @@ const HomePage: React.FunctionComponent<HomePageProps> = (props) => {
   useEffect(() => {
     if (urlParams === undefined) return;
 
-    console.log(urlParams);
-
     props.resetCertificateState();
     if (urlParams.query.q) {
       const action = JSON.parse(window.decodeURI(urlParams.query.q as string));

--- a/src/components/CertificateDropZone/Views/DefaultView.tsx
+++ b/src/components/CertificateDropZone/Views/DefaultView.tsx
@@ -10,7 +10,9 @@ export const DefaultView: React.FunctionComponent<DefaultViewProps> = ({ fileErr
       <img alt=".opencert Dropzone" src="/static/images/dropzone/dropzone_illustration.svg" />
     </div>
     {fileError && (
-      <p className="text-pink mb-2">File cannot be read. Please check that you have a valid .opencert file</p>
+      <p data-testid="invalid-message" className="text-pink mb-2">
+        File cannot be read. Please check that you have a valid .opencert file
+      </p>
     )}
     <h2 className="font-source-sans-pro text-gray-900 mb-2 text-md">Drag and drop your opencert file</h2>
     <div className="text-gray-700">

--- a/src/components/CertificateDropZone/Views/RetrievalErrorView.tsx
+++ b/src/components/CertificateDropZone/Views/RetrievalErrorView.tsx
@@ -12,7 +12,7 @@ export const RetrievalErrorView: React.FunctionComponent<RetrievalErrorViewProps
   <>
     <ErrorHeading title="The certificate can't be loaded" />
 
-    <div className="text-pink mt-4 mb-4">
+    <div data-testid="invalid-message" className="text-pink mt-4 mb-4">
       <h4 className="font-bold">Unable to load certificate with the provided parameters</h4>
       <p className="break-words">{retrieveCertificateByActionError}</p>
     </div>

--- a/src/components/CertificateDropZone/Views/UnverifiedView.tsx
+++ b/src/components/CertificateDropZone/Views/UnverifiedView.tsx
@@ -51,7 +51,7 @@ const DetailedErrors: React.FunctionComponent<DetailedErrorsProps> = ({ verifica
     }
   }
   const renderedError = errors.map((errorType, index) => (
-    <div className="text-pink mt-4 mb-8" key={index}>
+    <div data-testid="invalid-message" className="text-pink mt-4 mb-8" key={index}>
       <p className="text-md font-bold">{MESSAGES[errorType].failureTitle}</p>
       <p>{MESSAGES[errorType].failureMessage}</p>
     </div>

--- a/src/components/CertificateShareLink/CertificateShareLinkForm.tsx
+++ b/src/components/CertificateShareLink/CertificateShareLinkForm.tsx
@@ -62,7 +62,7 @@ class CertificateShareLinkForm extends Component<CertificateShareLinkFormProps> 
                 </div>
               </>
             ) : (
-              <div id="error-message" className="row justify-content-center my-5 text-red">
+              <div id="invalid-message" className="row justify-content-center my-5 text-red">
                 <i id="verify-invalid" className="fas fa-times-circle fa-2x" />{" "}
                 <p className="align-middle ml-2 mt-1">Could not generate sharing link.</p>
               </div>

--- a/src/components/Layout/Body.tsx
+++ b/src/components/Layout/Body.tsx
@@ -1,68 +1,15 @@
-import { ParsedUrlQuery } from "querystring";
-
-import { useRouter } from "next/router";
 import React from "react";
-import { useEffect, useState } from "react";
 import { Wogaa } from "../Analytics/wogaa";
-
-type UseUrlParamsThenScrubUrlParam = {
-  /** extraction and scrubbing will only happen if this is true */
-  enabled: boolean;
-};
-type UrlParams = {
-  uriFragment: string;
-  query: ParsedUrlQuery;
-};
-const useUrlParamsThenScrubUrl = ({ enabled }: UseUrlParamsThenScrubUrlParam): UrlParams | undefined => {
-  // urlParams will only be undefined before the second render
-  // being undefined means the urlParams has not been extracted and the url has not been scrubbed yet
-  const [urlParams, setUrlParams] = useState<UrlParams | undefined>(
-    !enabled
-      ? {
-          uriFragment: "",
-          query: {},
-        }
-      : undefined
-  );
-  const router = useRouter();
-
-  useEffect(() => {
-    if (enabled) {
-      setUrlParams((currUrlParams) => {
-        // once the fragment is set, we never update it again
-        if (currUrlParams !== undefined) {
-          return currUrlParams;
-        }
-
-        const savedFragment = window.location.hash.substring(1);
-        const savedQueryParam = { ...router.query };
-
-        // scrubbbb itttttt
-        window.location.hash = "";
-        router.replace({}, undefined, { shallow: true });
-        return {
-          uriFragment: savedFragment,
-          query: savedQueryParam,
-        };
-      });
-    }
-  }, [urlParams, router, enabled]);
-
-  return urlParams;
-};
 
 interface WrapperProps {
   children: React.ReactNode;
-  isScrubUrlBeforeLoadingWogaa?: boolean;
+  isLoadWogaa?: boolean;
 }
 
-export const Wrapper: React.FunctionComponent<WrapperProps> = ({ children, isScrubUrlBeforeLoadingWogaa = false }) => {
-  // urlParams being defined means the url has been extracted and scrubbed
-  const urlParams = useUrlParamsThenScrubUrl({ enabled: isScrubUrlBeforeLoadingWogaa });
+export const Wrapper: React.FunctionComponent<WrapperProps> = ({ children, isLoadWogaa = true }) => {
   return (
     <>
-      {!isScrubUrlBeforeLoadingWogaa && <Wogaa />}
-      {isScrubUrlBeforeLoadingWogaa && urlParams ? <Wogaa /> : null}
+      {isLoadWogaa ? <Wogaa /> : null}
       <div className="flex flex-col h-screen wrapper">{children}</div>
     </>
   );

--- a/src/components/tests/dns-verified.spec.js
+++ b/src/components/tests/dns-verified.spec.js
@@ -21,7 +21,7 @@ const Document = "./fixture/sample-dns-verified.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 const RenderedCertificate = Selector("#certificate-dropzone");
 
 const validateTextContent = async (t, component, texts) =>

--- a/src/components/tests/unverified-issuer.spec.js
+++ b/src/components/tests/unverified-issuer.spec.js
@@ -8,7 +8,7 @@ fixture("Unverified Certificate Rendering").page`http://localhost:3000`.beforeEa
 const Certificate = "./fixture/unverified-issuer.json";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());

--- a/src/sagas/sagatests/integration-contract-not-found.spec.js
+++ b/src/sagas/sagatests/integration-contract-not-found.spec.js
@@ -8,7 +8,7 @@ fixture("Contract Not Found").page`http://localhost:3000`.beforeEach(async () =>
 const Certificate = "./sample-mainnet.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());

--- a/src/sagas/sagatests/integration-invalidstore.spec.js
+++ b/src/sagas/sagatests/integration-invalidstore.spec.js
@@ -8,7 +8,7 @@ fixture("Invalid Store Cert").page`http://localhost:3000`.beforeEach(async () =>
 const Certificate = "./invalidstore.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());

--- a/src/sagas/sagatests/integration-merkle.spec.js
+++ b/src/sagas/sagatests/integration-merkle.spec.js
@@ -10,7 +10,7 @@ const Certificate2 = "./wrong-merkle-incorrect-length.opencert";
 const Certificate3 = "./wrong-merkle-arrayify-value.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());

--- a/src/sagas/sagatests/integration-multiple-invalidstore.spec.js
+++ b/src/sagas/sagatests/integration-multiple-invalidstore.spec.js
@@ -8,7 +8,7 @@ fixture("Multiple Invalid Stores Cert").page`http://localhost:3000`.beforeEach(a
 const Certificate = "./multipleinvalidstores.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());

--- a/src/sagas/sagatests/integration-tampered.spec.js
+++ b/src/sagas/sagatests/integration-tampered.spec.js
@@ -8,7 +8,7 @@ fixture("Tampered Cert").page`http://localhost:3000`.beforeEach(async () => {
 const Certificate = "./tampered.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());

--- a/src/sagas/sagatests/integration-unissued.spec.js
+++ b/src/sagas/sagatests/integration-unissued.spec.js
@@ -8,7 +8,7 @@ fixture("Unissued Cert").page`http://localhost:3000`.beforeEach(async () => {
 const Certificate = "./unissued.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
-const InvalidMessage = Selector(".invalid");
+const InvalidMessage = Selector('[data-testid="invalid-message"]');
 
 const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());


### PR DESCRIPTION
## Why
Previous pr scrubbed the url before loading wogaa, but did not use the scrubbed query params for universal action.

## What
1. move scrubbing and loading of wogaa based on scrubbing into verify page
2. update to use scrubbed `urlParams` instead of reading from next `router`