### PR TITLE
chore: improve tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
       - build
 orbs:
   browser-tools: circleci/browser-tools@1.4.8
+
 jobs:
   build:
     resource_class: large
@@ -13,9 +14,18 @@ jobs:
     steps:
       - checkout
       - browser-tools/install-chrome
+      - restore_cache:
+          keys:
+            - npm-cache-{{ checksum "package-lock.json" }}
+            # fallback to a previous cache if package-lock.json hasn't changed
+            - npm-cache-
       - run:
           name: install
           command: npm ci
+      - save_cache:
+          paths:
+            - ~/.npm
+          key: npm-cache-{{ checksum "package-lock.json" }}
       - run:
           name: lint
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - image: "cimg/node:18.20.3-browsers"
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
       - run:
           name: install
           command: npm ci

--- a/src/components/tests/did-dns-verified.spec.js
+++ b/src/components/tests/did-dns-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("DID-DNS Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -9,9 +10,6 @@ const Document = "./fixture/dns-did-signed.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when dns is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/dns-registry-verified.spec.js
+++ b/src/components/tests/dns-registry-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("DNS and Registry Verified for Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -9,9 +10,6 @@ const Document = "./fixture/sample-registry-dns-verified.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when dns and registry is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/dns-verified.spec.js
+++ b/src/components/tests/dns-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector, RequestMock } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 const googleDnsDown = RequestMock()
   .onRequestTo({ url: "https://dns.google/resolve?name=example.openattestation.com&type=TXT" })
@@ -23,9 +24,6 @@ const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
 const RenderedCertificate = Selector("#certificate-dropzone");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when dns is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/download-certificate.spec.js
+++ b/src/components/tests/download-certificate.spec.js
@@ -6,6 +6,8 @@ import { waitForReact } from "testcafe-react-selectors";
 import TestDocument2 from "./fixture/sample-dns-verified-special-characters.json";
 import TestDocument1 from "./fixture/sample-dns-verified.json";
 
+import { validateTextContent } from "./utils";
+
 fixture("Download Certificate").page`http://localhost:3000`
   .afterEach(async (t) => {
     // Clean up files after each test
@@ -21,9 +23,6 @@ const Document2 = "./fixture/sample-dns-verified-special-characters.json";
 const StatusButton = Selector("#certificate-status");
 const DownloadLink = Selector("a").withAttribute("download");
 const DownloadButton = Selector("#btn-download");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 // From https://stackoverflow.com/a/57624660/950462
 const waitForFileDownload = async (t, filePath) => {

--- a/src/components/tests/load-action-encrypted-certificate.spec.js
+++ b/src/components/tests/load-action-encrypted-certificate.spec.js
@@ -1,6 +1,7 @@
 import { Selector } from "testcafe";
 import "isomorphic-fetch";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Load action from encrypted certificate").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -10,9 +11,6 @@ const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
 const CertificateDropzone = Selector("#certificate-dropzone");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 const key = "894c5b45a61d79fe46835e2c2b363875f0a1240db447bb3db77c2cf79568e279";
 

--- a/src/components/tests/load-action-plain-certificate.spec.js
+++ b/src/components/tests/load-action-plain-certificate.spec.js
@@ -1,6 +1,7 @@
 import { Selector } from "testcafe";
 import "isomorphic-fetch";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Load action from plain certificate").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -10,9 +11,6 @@ const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
 const CertificateDropzone = Selector("#certificate-dropzone");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Load document from action should work when url is valid", async (t) => {
   const action = {

--- a/src/components/tests/multi-dns-verified-certificate-store.spec.js
+++ b/src/components/tests/multi-dns-verified-certificate-store.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Multiple DNS Verified for Certificate Rendering using certificate store")
   .page`http://localhost:3000`.beforeEach(async () => {
@@ -10,9 +11,6 @@ const Document = "./fixture/sample-multidns-verified-certificate-store.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when multiple dns is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/multi-dns-verified.spec.js
+++ b/src/components/tests/multi-dns-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Multiple DNS Verified for Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -9,9 +10,6 @@ const Document = "./fixture/sample-multidns-verified.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when multiple dns is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/multi-registry-verified.spec.js
+++ b/src/components/tests/multi-registry-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Multiple Registry Verified for Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -7,9 +8,6 @@ fixture("Multiple Registry Verified for Certificate Rendering").page`http://loca
 
 const Document = "./fixture/sample-multiregistry-verified.json";
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when multiple registry is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/obfuscated-document-verified.spec.js
+++ b/src/components/tests/obfuscated-document-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Obfuscate Note Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -10,9 +11,6 @@ const IframeBlock = Selector("#iframe");
 const StatusButton = Selector("#certificate-status");
 const SampleTemplate = Selector("#rendered-certificate");
 const ObfuscationNote = Selector("#obfuscation-note");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when single registry is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/registry-verified.spec.js
+++ b/src/components/tests/registry-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector, ClientFunction } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Registry Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -11,9 +12,6 @@ const TranscriptButton = Selector("[data-testid='transcript']");
 const MediaButton = Selector("[data-testid='media']");
 const StatusButton = Selector("#certificate-status");
 const SampleTemplate = Selector("#rendered-certificate");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when single registry is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/components/tests/unverified-issuer.spec.js
+++ b/src/components/tests/unverified-issuer.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Unverified Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -9,9 +10,6 @@ const Certificate = "./fixture/unverified-issuer.json";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Error view rendered when certificate issuers are unverified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate]);

--- a/src/components/tests/utils.js
+++ b/src/components/tests/utils.js
@@ -1,0 +1,2 @@
+export const validateTextContent = async (t, component, texts) =>
+  Promise.all(texts.map(async (text) => await t.expect(component.textContent).contains(text)));

--- a/src/components/tests/utils.js
+++ b/src/components/tests/utils.js
@@ -1,2 +1,4 @@
-export const validateTextContent = async (t, component, texts) =>
-  Promise.all(texts.map(async (text) => await t.expect(component.textContent).contains(text)));
+export const validateTextContent = async (t, component, texts) => {
+  t.expect(component.exists).ok();
+  return Promise.all(texts.map(async (text) => await t.expect(component.textContent).contains(text)));
+};

--- a/src/components/tests/utils.js
+++ b/src/components/tests/utils.js
@@ -1,4 +1,4 @@
 export const validateTextContent = async (t, component, texts) => {
-  t.expect(component.exists).ok();
-  return Promise.all(texts.map(async (text) => await t.expect(component.textContent).contains(text)));
+  await t.expect(component.exists).ok();
+  await Promise.all(texts.map(async (text) => await t.expect(component.textContent).contains(text)));
 };

--- a/src/components/tests/verified-unverified-issuer.spec.js
+++ b/src/components/tests/verified-unverified-issuer.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "./utils";
 
 fixture("Any one of DNS or Registry Verified for Certificate Rendering").page`http://localhost:3000/viewer`.beforeEach(
   async () => {
@@ -11,9 +12,6 @@ const Document = "./fixture/verified-unverified-issuer.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample doc is rendered correctly when any one of dns or registry is verified and doc store mismatch in domain", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Document]);

--- a/src/integration/v4/v4-verified.spec.js
+++ b/src/integration/v4/v4-verified.spec.js
@@ -1,5 +1,6 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
 fixture("OA v4 DID-DNS Certificate Rendering").page`http://localhost:3000`.beforeEach(async () => {
   await waitForReact();
@@ -9,9 +10,6 @@ const EmbeddedRendererDoc = "./fixtures/v4_embedded_renderer.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample v4 document using embedded renderer is rendered correctly when dns is verified", async (t) => {
   await t.setFilesToUpload("input[type=file]", [EmbeddedRendererDoc]);

--- a/src/sagas/sagatests/integration-alternate-network.spec.js
+++ b/src/sagas/sagatests/integration-alternate-network.spec.js
@@ -1,7 +1,9 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
-fixture("Alternate Network Cert").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Alternate Network Cert").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait();
   await waitForReact();
 });
 
@@ -10,9 +12,6 @@ const Certificate = "./sample-amoy.opencert";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample amoy document is rendered correctly", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate]);

--- a/src/sagas/sagatests/integration-alternate-network.spec.js
+++ b/src/sagas/sagatests/integration-alternate-network.spec.js
@@ -3,7 +3,7 @@ import { waitForReact } from "testcafe-react-selectors";
 import { validateTextContent } from "../../components/tests/utils";
 
 fixture("Alternate Network Cert").page`http://localhost:3000`.beforeEach(async (t) => {
-  await t.wait();
+  await t.wait(1000);
   await waitForReact();
 });
 

--- a/src/sagas/sagatests/integration-contract-not-found.spec.js
+++ b/src/sagas/sagatests/integration-contract-not-found.spec.js
@@ -1,7 +1,10 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
 
-fixture("Contract Not Found").page`http://localhost:3000`.beforeEach(async () => {
+import { validateTextContent } from "../../components/tests/utils";
+
+fixture("Contract Not Found").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -9,9 +12,6 @@ const Certificate = "./sample-mainnet.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 // Contract not found means that the contract address is perfectly valid, but it does not exist on the network
 test("Mainnet certificate should result in contract not found error message on goerli", async (t) => {

--- a/src/sagas/sagatests/integration-invalidstore.spec.js
+++ b/src/sagas/sagatests/integration-invalidstore.spec.js
@@ -1,7 +1,9 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
-fixture("Invalid Store Cert").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Invalid Store Cert").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -9,9 +11,6 @@ const Certificate = "./invalidstore.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Invalid Store certificate's error message is correct", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate]);

--- a/src/sagas/sagatests/integration-merkle.spec.js
+++ b/src/sagas/sagatests/integration-merkle.spec.js
@@ -1,7 +1,9 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
-fixture("Wrong Merkle Cert").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Wrong Merkle Cert").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -11,9 +13,6 @@ const Certificate3 = "./wrong-merkle-arrayify-value.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Merkle root that is of odd-length should result in correct error message", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate1]);

--- a/src/sagas/sagatests/integration-multiple-invalidstore.spec.js
+++ b/src/sagas/sagatests/integration-multiple-invalidstore.spec.js
@@ -1,7 +1,9 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
-fixture("Multiple Invalid Stores Cert").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Multiple Invalid Stores Cert").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -9,9 +11,6 @@ const Certificate = "./multipleinvalidstores.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Multiple Invalid Stores certificate's error message is correct", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate]);

--- a/src/sagas/sagatests/integration-server-error.spec.js
+++ b/src/sagas/sagatests/integration-server-error.spec.js
@@ -1,7 +1,8 @@
 import { RequestMock, Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
 
-fixture("Ethereum Provider HTTP Server Error").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Ethereum Provider HTTP Server Error").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -33,9 +34,6 @@ const DropzoneViewWrapper = Selector("[data-testid='dropzone-view-wrapper']");
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test.requestHooks(badGatewayMockInfuraOnly)(
   "Sample document is rendered correctly when only infura is down",

--- a/src/sagas/sagatests/integration-server-error.spec.js
+++ b/src/sagas/sagatests/integration-server-error.spec.js
@@ -1,5 +1,6 @@
 import { RequestMock, Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
 fixture("Ethereum Provider HTTP Server Error").page`http://localhost:3000`.beforeEach(async (t) => {
   await t.wait(1000);

--- a/src/sagas/sagatests/integration-tampered.spec.js
+++ b/src/sagas/sagatests/integration-tampered.spec.js
@@ -1,7 +1,9 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
-fixture("Tampered Cert").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Tampered Cert").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -9,9 +11,6 @@ const Certificate = "./tampered.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Tampered certificate's error message is correct", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate]);

--- a/src/sagas/sagatests/integration-unissued.spec.js
+++ b/src/sagas/sagatests/integration-unissued.spec.js
@@ -1,7 +1,9 @@
 import { Selector } from "testcafe";
 import { waitForReact } from "testcafe-react-selectors";
+import { validateTextContent } from "../../components/tests/utils";
 
-fixture("Unissued Cert").page`http://localhost:3000`.beforeEach(async () => {
+fixture("Unissued Cert").page`http://localhost:3000`.beforeEach(async (t) => {
+  await t.wait(1000);
   await waitForReact();
 });
 
@@ -9,9 +11,6 @@ const Certificate = "./unissued.opencert";
 
 const RenderedCertificate = Selector("#certificate-dropzone");
 const InvalidMessage = Selector('[data-testid="invalid-message"]');
-
-const validateTextContent = async (t, component, texts) =>
-  texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Unissued certificate's error message is correct", async (t) => {
   await t.setFilesToUpload("input[type=file]", [Certificate]);


### PR DESCRIPTION
## Why
1. Flaky tests seemingly due to rate limiting by our RPC endpoints

## What
1. added wait time before each of the test that would call the rpc
2. abstract out `validateTextContent`
3. adding npm deps caching in ci
4. only install chrome browser in ci