### PR TITLE
fix: hosted doc decryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "react-ga4": "^1.4.1",
         "react-google-recaptcha": "^2.1.0",
         "react-redux": "^9.1.2",
-        "redux-saga": "^1.3.0"
+        "redux-saga": "^1.3.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@babel/core": "^7.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "analyze": "BUNDLE_ANALYZE=browser npm run start",
     "dev-cli": "node -r esm ./scripts/cli.js",
     "serve-static": "http-server out -s -p 3000",
-    "integration": "testcafe chrome src/**/*.spec.js --ts-config-path ./tsconfig.json",
+    "integration": "testcafe chrome src/**/*.spec.js --selector-timeout 10000 --ts-config-path ./tsconfig.json",
     "integration:single": "testcafe chrome -L --app \"npm run serve-static\"",
     "integration:headless": "testcafe -c 1 'chrome --headless=new --disable-web-security' --selector-timeout 300000 src/**/*.spec.js",
     "integration:watch": "nodemon --exec \"npm run integration\" --watch src",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "react-ga4": "^1.4.1",
     "react-google-recaptcha": "^2.1.0",
     "react-redux": "^9.1.2",
-    "redux-saga": "^1.3.0"
+    "redux-saga": "^1.3.0",
+    "zod": "^3.23.8"
   },
   "license": "ISC",
   "devDependencies": {
@@ -133,7 +134,7 @@
       "@typescript-eslint/explicit-member-accessibility": 0,
       "@typescript-eslint/no-use-before-define": 0,
       "@typescript-eslint/no-unused-vars": [
-        "warn", 
+        "warn",
         {
           "argsIgnorePattern": "^_",
           "varsIgnorePattern": "^_",

--- a/src/components/tests/load-action-encrypted-certificate.spec.js
+++ b/src/components/tests/load-action-encrypted-certificate.spec.js
@@ -137,7 +137,7 @@ test("Load document from action should fail when the required key is not provide
   await validateTextContent(t, CertificateDropzone, [
     "The certificate can't be loaded",
     "Unable to load certificate with the provided parameters",
-    "Unable to decrypt certificate with key=undefined and type=OPEN-ATTESTATION-TYPE-1",
+    "Key is required to decrypt certificate but received key=undefined and type=OPEN-ATTESTATION-TYPE-1",
   ]);
 });
 

--- a/src/components/tests/load-action-encrypted-certificate.spec.js
+++ b/src/components/tests/load-action-encrypted-certificate.spec.js
@@ -68,7 +68,7 @@ test("Load document from action should fail when action type is invalid", async 
   const action = {
     type: "DOCUM",
     payload: {
-      uri: `https://gist.githubusercontent.com/john-dot-oa/0dfa4b0decedc120ef19cd4d6643e315/raw/a0da74ad4568826dc90e9e865dac1ec00f68b124/opencerts-website-e2e.json`,
+      uri: `https://example.com/sample.json`, // Not important as invalid action.type will throw error first
       key,
       permittedAction: ["STORE"],
       redirect: "https://opencerts.io/",
@@ -88,7 +88,7 @@ test("Load document from action should fail when key is invalid (key from anchor
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: `https://gist.githubusercontent.com/john-dot-oa/0dfa4b0decedc120ef19cd4d6643e315/raw/a0da74ad4568826dc90e9e865dac1ec00f68b124/opencerts-website-e2e.json`,
+      uri: `https://gist.githubusercontent.com/john-dot-oa/3069a02fe96445bc71ff7eb15a7f93c0/raw/98488d7e478ac7072d9210d8615aed8bb37506e4/opencerts-website-sepolia-e2e.json`,
       permittedAction: ["STORE"],
       redirect: "https://opencerts.io/",
     },
@@ -108,7 +108,7 @@ test("Load document from action should fail when key is invalid", async (t) => {
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: `https://gist.githubusercontent.com/john-dot-oa/0dfa4b0decedc120ef19cd4d6643e315/raw/a0da74ad4568826dc90e9e865dac1ec00f68b124/opencerts-website-e2e.json`,
+      uri: `https://gist.githubusercontent.com/john-dot-oa/3069a02fe96445bc71ff7eb15a7f93c0/raw/98488d7e478ac7072d9210d8615aed8bb37506e4/opencerts-website-sepolia-e2e.json`,
       permittedAction: ["STORE"],
       redirect: "https://opencerts.io/",
       key: "2a237b35cb50544a2c9a4b4a629e7c547bd1ff4a0137489700891532001e83f6", // random key, must have correct length
@@ -127,7 +127,7 @@ test("Load document from action should fail when the required key is not provide
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: `https://gist.githubusercontent.com/john-dot-oa/0dfa4b0decedc120ef19cd4d6643e315/raw/a0da74ad4568826dc90e9e865dac1ec00f68b124/opencerts-website-e2e.json`,
+      uri: `https://gist.githubusercontent.com/john-dot-oa/3069a02fe96445bc71ff7eb15a7f93c0/raw/98488d7e478ac7072d9210d8615aed8bb37506e4/opencerts-website-sepolia-e2e.json`,
       permittedAction: ["STORE"],
       redirect: "https://opencerts.io/",
     },
@@ -145,7 +145,7 @@ test("Load document from action should fail when url is invalid", async (t) => {
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: `https://gist.githubusercontent.com/john-dot-oa/0dfa4b0decedc120ef19cd4d6643e315/raw/a0da74ad4568826dc90e9e865dac1ec00f68b124/opencerts-website-e2e.jsondasdasd`,
+      uri: `https://gist.githubusercontent.com/john-dot-oa/1234/raw/5678/non-existent.json`, // random url, must follow Gist URL format
       permittedAction: ["STORE"],
       redirect: "https://opencerts.io/",
       key,
@@ -156,6 +156,6 @@ test("Load document from action should fail when url is invalid", async (t) => {
   await validateTextContent(t, CertificateDropzone, [
     "The certificate can't be loaded",
     "Unable to load certificate with the provided parameters",
-    "Unable to load the certificate from https://gist.githubusercontent.com/john-dot-oa/0dfa4b0decedc120ef19cd4d6643e315/raw/a0da74ad4568826dc90e9e865dac1ec00f68b124/opencerts-website-e2e.jsondasdasd",
+    "Unable to load the certificate from https://gist.githubusercontent.com/john-dot-oa/1234/raw/5678/non-existent.json",
   ]);
 });

--- a/src/components/tests/load-action-encrypted-certificate.spec.js
+++ b/src/components/tests/load-action-encrypted-certificate.spec.js
@@ -14,7 +14,7 @@ const CertificateDropzone = Selector("#certificate-dropzone");
 
 const key = "894c5b45a61d79fe46835e2c2b363875f0a1240db447bb3db77c2cf79568e279";
 
-test("Load document from action should work when action is valid (key from anchor)", async (t) => {
+test("Load OA v2.0 document from action should work when action is valid (key from anchor)", async (t) => {
   const anchor = { key };
   const action = {
     type: "DOCUMENT",
@@ -40,7 +40,34 @@ test("Load document from action should work when action is valid (key from ancho
   ]);
 });
 
-test("Load document from action should work when action is valid", async (t) => {
+test("Load OA v4.0 document from action should work when action is valid (key from anchor)", async (t) => {
+  const anchor = { key };
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://gist.githubusercontent.com/john-dot-oa/320778f9e9d93c80e03fe18040b399d0/raw/19d099d51fde74234b72bf4f555c65f6954b956c/opencerts-website-did-demo-encrypted-v4.json`,
+      permittedAction: ["STORE"],
+      redirect: "https://opencerts.io/",
+    },
+  };
+
+  await t.navigateTo(
+    `http://localhost:3000/?q=${encodeURI(JSON.stringify(action))}#${encodeURI(JSON.stringify(anchor))}`
+  );
+  await validateTextContent(t, StatusButton, ["EXAMPLE.OPENATTESTATION.COM"]);
+
+  await t.switchToIframe(IframeBlock);
+
+  await validateTextContent(t, SampleTemplate, [
+    "OpenCerts Demo",
+    "Your Name",
+    "has successfully completed the",
+    "John Demo",
+  ]);
+});
+
+// Note: This is a deprecated way of including the key. The key should be part of the anchor (#): https://github.com/Open-Attestation/adr/blob/master/universal_actions.md#proposed-solution
+test("Load document from action should work when action is valid (key from query param to maintain backwards compatibility)", async (t) => {
   const action = {
     type: "DOCUMENT",
     payload: {

--- a/src/components/tests/load-action-plain-certificate.spec.js
+++ b/src/components/tests/load-action-plain-certificate.spec.js
@@ -12,7 +12,7 @@ const SampleTemplate = Selector("#rendered-certificate");
 const StatusButton = Selector("#certificate-status");
 const CertificateDropzone = Selector("#certificate-dropzone");
 
-test("Load document from action should work when url is valid", async (t) => {
+test("Load document from action should work when url is valid (OA v2.0)", async (t) => {
   const action = {
     type: "DOCUMENT",
     payload: {
@@ -33,6 +33,29 @@ test("Load document from action should work when url is valid", async (t) => {
     "John Demo",
   ]);
 });
+
+test("Load document from action should work when url is valid (OA v4.0)", async (t) => {
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://gist.githubusercontent.com/john-dot-oa/320778f9e9d93c80e03fe18040b399d0/raw/19d099d51fde74234b72bf4f555c65f6954b956c/opencerts-website-did-demo-v4.json`,
+      redirect: "https://opencerts.io/",
+    },
+  };
+
+  await t.navigateTo(`http://localhost:3000/?q=${encodeURI(JSON.stringify(action))}`);
+  await validateTextContent(t, StatusButton, ["EXAMPLE.OPENATTESTATION.COM"]);
+
+  await t.switchToIframe(IframeBlock);
+
+  await validateTextContent(t, SampleTemplate, [
+    "OpenCerts Demo",
+    "Your Name",
+    "has successfully completed the",
+    "John Demo",
+  ]);
+});
+
 test("Load document from action should fail when url is invalid", async (t) => {
   const action = {
     type: "DOCUMENT",

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -296,7 +296,7 @@ export function* retrieveCertificateByActionSaga({
           })
         );
       } catch (e) {
-        throw new Error(`Unable to decrypt certificate with key=${key} and type=${certificate.type}`);
+        throw new Error(`Error decrypting message with key=${key} and type=${certificate.type}`);
       }
     }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,5 +1,5 @@
-import { v2, v3, v4 } from "@govtechsg/open-attestation";
 import { IEncryptionResults } from "@govtechsg/oa-encryption";
+import { v2, v3, v4 } from "@govtechsg/open-attestation";
 import { z } from "zod";
 
 // for the moment we don't need to use specifically signer types and it raises an error in some methods that don't really expect signed document, so keeping it like this

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,21 @@
 import { v2, v3, v4 } from "@govtechsg/open-attestation";
+import { IEncryptionResults } from "@govtechsg/oa-encryption";
+import { z } from "zod";
 
 // for the moment we don't need to use specifically signer types and it raises an error in some methods that don't really expect signed document, so keeping it like this
 export type WrappedOrSignedOpenCertsDocument = v2.WrappedDocument | v3.WrappedDocument | v4.WrappedDocument;
+
+// type guard for encrypted certificates
+type EncryptedCertificate = Omit<IEncryptionResults, "key">;
+export const isEncrypted = (certificate: unknown): certificate is EncryptedCertificate => {
+  const schema: z.ZodType<EncryptedCertificate> = z.object({
+    cipherText: z.string(),
+    iv: z.string(),
+    tag: z.string(),
+    type: z.string(),
+  });
+
+  const { success } = schema.safeParse(certificate);
+
+  return success;
+};


### PR DESCRIPTION
## Context
- Conditional checking for whether OA decryption is needed is [too loose on OpenCerts website](https://github.com/OpenCerts/opencerts-website/blob/95174309aa7d0f9dacd8133361020da7c726074a/src/sagas/certificate.ts#L290)
- OA v4.0 documents has a `type` property

This results in the following error as it thinks a fetched OA v4.0 document is encrypted and fails to decrypt it:
![dev opencerts io__q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A5173%2Fstatic%2Fdocuments%2Ftranscript-did-embedded-renderer-v4 json%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redire](https://github.com/user-attachments/assets/d1996983-09d9-4f31-8d90-7c8a44176d5d)

## The fix
Create a stricter type guard with Zod to check whether certificate is encrypted