### PR TITLE
fix: rename to technical query

### DIFF
--- a/src/components/Layout/FooterBar.tsx
+++ b/src/components/Layout/FooterBar.tsx
@@ -23,7 +23,7 @@ export const FooterBar: React.FunctionComponent = () => (
             </li>
             <li>
               <a href="https://go.gov.sg/opencerts-feedback" target="_blank" rel="noopener noreferrer">
-                Feedback
+                Technical Query
               </a>
             </li>
           </ul>


### PR DESCRIPTION
## What does this PR do?

Rename the "Feedback" link to "Technical Query" to more accurately represent what the form is for