### PR TITLE
fix: avoid unnecessary retries if call selector is "supportsInterface(bytes4)"

### DIFF
--- a/src/services/failover-provider.ts
+++ b/src/services/failover-provider.ts
@@ -56,6 +56,13 @@ export class OAFailoverProvider extends providers.StaticJsonRpcProvider {
         if (i === this.failoverProviders.length - 1) {
           throw error;
         }
+        // Avoid retries if the function selector inside calldata is "supportsInterface(bytes4)"
+        // isBatchableDocumentStore: https://github.com/Open-Attestation/oa-verify/blob/0492679f4f24df164d93e699a5845b30d39ab14d/src/common/utils.ts#L237-L244
+        // Decoded: https://calldata.swiss-knife.xyz/decoder?calldata=0x01ffc9a7dcfd074500000000000000000000000000000000000000000000000000000000
+        // Keccak256("supportsInterface(bytes4)") = 0x01ffc9a7
+        if (/^0x01ffc9a7.*$/.test(params?.transaction?.data)) {
+          throw error;
+        }
         // Attempt the next provider
         else {
           continue;


### PR DESCRIPTION
## Context

- `OAFailoverProvider` is designed to retry on another provider upon an error (e.g. to accommodate situations where an Ethereum provider is down)
- [`oa-verify` library has a function](https://github.com/Open-Attestation/oa-verify/blob/b4e30a5def70124ef668ba0feff3d8298ed37e5b/src/common/utils.ts#L237-L244) that checks `isBatchableDocumentStore()`. Function is expected to throw an error if it does not support interface `0xdcfd0745`
- This inadvertently causes verifications to be a bit slower as it will always retry and exhaust all the available Ethereum providers

## What does this PR do?

- Avoid retries if the function selector inside calldata is `"supportsInterface(bytes4)"`